### PR TITLE
feat: fix local dependencies version on pre-releases

### DIFF
--- a/lib/createInlinePluginCreator.js
+++ b/lib/createInlinePluginCreator.js
@@ -86,6 +86,7 @@ function createInlinePluginCreator(packages, multiContext, synchronizer, flags) 
 		 */
 		const analyzeCommits = async (pluginOptions, context) => {
 			const firstParentBranch = flags.firstParent ? context.branch.name : undefined;
+			pkg._preRelease = context.branch.prerelease || null;
 
 			// Filter commits by directory.
 			commits = await getCommitsFiltered(cwd, dir, context.lastRelease.gitHead, firstParentBranch);

--- a/lib/updateDeps.js
+++ b/lib/updateDeps.js
@@ -12,6 +12,10 @@ const semver = require("semver");
 const getNextVersion = (pkg) => {
 	const lastVersion = pkg._lastRelease && pkg._lastRelease.version;
 
+	if (pkg._preRelease) {
+		return lastVersion ? semver.inc(lastVersion, "prerelease", pkg._preRelease) : `1.0.0-${pkg._preRelease}.1`;
+	}
+
 	return lastVersion && typeof pkg._nextType === "string"
 		? semver.inc(lastVersion, pkg._nextType)
 		: lastVersion || "1.0.0";

--- a/lib/updateDeps.js
+++ b/lib/updateDeps.js
@@ -12,13 +12,22 @@ const semver = require("semver");
 const getNextVersion = (pkg) => {
 	const lastVersion = pkg._lastRelease && pkg._lastRelease.version;
 
-	if (pkg._preRelease) {
-		return lastVersion ? semver.inc(lastVersion, "prerelease", pkg._preRelease) : `1.0.0-${pkg._preRelease}.1`;
-	}
-
 	return lastVersion && typeof pkg._nextType === "string"
 		? semver.inc(lastVersion, pkg._nextType)
 		: lastVersion || "1.0.0";
+};
+
+/**
+ * Resolve next package version on prereleases.
+ *
+ * @param {Package} pkg Package object.
+ * @returns {string|undefined} Next pkg version.
+ * @internal
+ */
+const getNextPreVersion = (pkg) => {
+	const lastVersion = pkg._lastRelease && pkg._lastRelease.version;
+
+	return lastVersion ? semver.inc(lastVersion, "prerelease", pkg._preRelease) : `1.0.0-${pkg._preRelease}.1`;
 };
 
 /**
@@ -94,7 +103,7 @@ const getDependentRelease = (pkg, bumpStrategy, releaseStrategy, ignore) => {
 			// 1. Any local dep package itself has changed
 			// 2. Any local dep package has local deps that have changed.
 			const nextType = resolveReleaseType(p, bumpStrategy, releaseStrategy,[...ignore, ...localDeps]);
-			const nextVersion = getNextVersion(p);
+			const nextVersion = p._preRelease ? getNextPreVersion(p) : getNextVersion(p);
 			const lastVersion = pkg._lastRelease && pkg._lastRelease.version;
 
 			// 3. And this change should correspond to manifest updating rule.
@@ -173,6 +182,7 @@ const updateManifestDeps = (pkg) => {
 
 module.exports = {
 	getNextVersion,
+	getNextPreVersion,
 	updateManifestDeps,
 	resolveReleaseType,
 	resolveNextVersion,

--- a/test/helpers/file.js
+++ b/test/helpers/file.js
@@ -1,5 +1,5 @@
 const { basename, join } = require("path");
-const { copyFileSync, existsSync, mkdirSync, lstatSync, readdirSync, readFileSync } = require("fs");
+const { copyFileSync, existsSync, mkdirSync, lstatSync, readdirSync, readFileSync, writeFileSync } = require("fs");
 
 // Deep copy a directory.
 function copyDirectory(source, target) {
@@ -37,8 +37,16 @@ function isDirectory(path) {
 	return typeof path === "string" && existsSync(path) && lstatSync(path).isDirectory();
 }
 
+// Creates testing files on all specified folders.
+function createNewTestingFiles(folders, cwd) {
+	folders.forEach((fld) => {
+		writeFileSync(`${cwd}/${fld}test.txt`, fld);
+	});
+}
+
 // Exports.
 module.exports = {
 	copyDirectory,
 	isDirectory,
+	createNewTestingFiles,
 };

--- a/test/helpers/git.js
+++ b/test/helpers/git.js
@@ -65,9 +65,10 @@ function gitInitRemote() {
  * _Created in a temp folder._
  *
  * @param {string} cwd The cwd to create and set the origin for.
+ * @param {string} releaseBranch="null" Optional branch to be added in case of prerelease is activated for a branch.
  * @return {Promise<string>} Promise that resolves to string URL of the of the remote origin.
  */
-function gitInitOrigin(cwd) {
+function gitInitOrigin(cwd, releaseBranch = null) {
 	// Check params.
 	check(cwd, "cwd: absolute");
 
@@ -76,6 +77,13 @@ function gitInitOrigin(cwd) {
 
 	// Set origin on local repo.
 	execa.sync("git", ["remote", "add", "origin", url], { cwd });
+
+	// Set up a release branch. Return to master afterwards.
+	if (releaseBranch) {
+		execa.sync("git", ["checkout", "-b", releaseBranch], { cwd });
+		execa.sync("git", ["checkout", "master"], { cwd });
+	}
+
 	execa.sync("git", ["push", "--all", "origin"], { cwd });
 
 	// Return URL for remote.

--- a/test/lib/multiSemanticRelease.test.js
+++ b/test/lib/multiSemanticRelease.test.js
@@ -2,7 +2,7 @@ const { writeFileSync } = require("fs");
 const path = require("path");
 const { Signale } = require("signale");
 const { WritableStreamBuffer } = require("stream-buffers");
-const { copyDirectory } = require("../helpers/file");
+const { copyDirectory, createNewTestingFiles } = require("../helpers/file");
 const {
 	gitInit,
 	gitAdd,
@@ -139,6 +139,297 @@ describe("multiSemanticRelease()", () => {
 			devDependencies: {
 				"msr-test-b": "1.0.0",
 				"msr-test-d": "1.0.0",
+			},
+		});
+	});
+	test("Initial commit (changes in all packages with prereleases)", async () => {
+		// Create Git repo with copy of Yarn workspaces fixture.
+		const cwd = gitInit("master", "release");
+		copyDirectory(`test/fixtures/yarnWorkspaces/`, cwd);
+		const sha = gitCommitAll(cwd, "feat: Initial release");
+		gitInitOrigin(cwd, "release");
+		gitPush(cwd);
+
+		// Capture output.
+		const stdout = new WritableStreamBuffer();
+		const stderr = new WritableStreamBuffer();
+
+		// Call multiSemanticRelease()
+		// Doesn't include plugins that actually publish.
+		const multiSemanticRelease = require("../../");
+		const result = await multiSemanticRelease(
+			[
+				`packages/a/package.json`,
+				`packages/b/package.json`,
+				`packages/c/package.json`,
+				`packages/d/package.json`,
+			],
+			{
+				branches: [{ name: "master", prerelease: "dev" }, { name: "release" }],
+			},
+			{ cwd, stdout, stderr }
+		);
+
+		// Get stdout and stderr output.
+		const err = stderr.getContentsAsString("utf8");
+		expect(err).toBe(false);
+		const out = stdout.getContentsAsString("utf8");
+		expect(out).toMatch("Started multirelease! Loading 4 packages...");
+		expect(out).toMatch("Loaded package msr-test-a");
+		expect(out).toMatch("Loaded package msr-test-b");
+		expect(out).toMatch("Loaded package msr-test-c");
+		expect(out).toMatch("Loaded package msr-test-d");
+		expect(out).toMatch("Queued 4 packages! Starting release...");
+		expect(out).toMatch("Created tag msr-test-a@1.0.0-dev.1");
+		expect(out).toMatch("Created tag msr-test-b@1.0.0-dev.1");
+		expect(out).toMatch("Created tag msr-test-c@1.0.0-dev.1");
+		expect(out).toMatch("Created tag msr-test-d@1.0.0-dev.1");
+		expect(out).toMatch("Released 4 of 4 packages, semantically!");
+
+		// A.
+		expect(result[0].name).toBe("msr-test-a");
+		expect(result[0].result.lastRelease).toEqual({});
+		expect(result[0].result.nextRelease).toMatchObject({
+			gitHead: sha,
+			gitTag: "msr-test-a@1.0.0-dev.1",
+			type: "minor",
+			version: "1.0.0-dev.1",
+		});
+		expect(result[0].result.nextRelease.notes).toMatch("# msr-test-a 1.0.0-dev.1");
+		expect(result[0].result.nextRelease.notes).toMatch("### Features\n\n* Initial release");
+		expect(result[0].result.nextRelease.notes).toMatch(
+			"### Dependencies\n\n* **msr-test-c:** upgraded to 1.0.0-dev.1"
+		);
+
+		// B.
+		expect(result[1].name).toBe("msr-test-b");
+		expect(result[1].result.lastRelease).toEqual({});
+		expect(result[1].result.nextRelease).toMatchObject({
+			gitHead: sha,
+			gitTag: "msr-test-b@1.0.0-dev.1",
+			type: "minor",
+			version: "1.0.0-dev.1",
+		});
+		expect(result[1].result.nextRelease.notes).toMatch("# msr-test-b 1.0.0-dev.1");
+		expect(result[1].result.nextRelease.notes).toMatch("### Features\n\n* Initial release");
+		expect(result[1].result.nextRelease.notes).toMatch(
+			"### Dependencies\n\n* **msr-test-a:** upgraded to 1.0.0-dev.1\n* **msr-test-c:** upgraded to 1.0.0-dev.1"
+		);
+
+		// C.
+		expect(result[2].name).toBe("msr-test-c");
+		expect(result[2].result.lastRelease).toEqual({});
+		expect(result[2].result.nextRelease).toMatchObject({
+			gitHead: sha,
+			gitTag: "msr-test-c@1.0.0-dev.1",
+			type: "minor",
+			version: "1.0.0-dev.1",
+		});
+		expect(result[2].result.nextRelease.notes).toMatch("# msr-test-c 1.0.0-dev.1");
+		expect(result[2].result.nextRelease.notes).toMatch("### Features\n\n* Initial release");
+		expect(result[2].result.nextRelease.notes).toMatch(
+			"### Dependencies\n\n* **msr-test-b:** upgraded to 1.0.0-dev.1"
+		);
+
+		// D.
+		expect(result[3].name).toBe("msr-test-d");
+		expect(result[3].result.lastRelease).toEqual({});
+		expect(result[3].result.nextRelease).toMatchObject({
+			gitHead: sha,
+			gitTag: "msr-test-d@1.0.0-dev.1",
+			type: "minor",
+			version: "1.0.0-dev.1",
+		});
+		expect(result[3].result.nextRelease.notes).toMatch("# msr-test-d 1.0.0-dev.1");
+		expect(result[3].result.nextRelease.notes).toMatch("### Features\n\n* Initial release");
+		expect(result[3].result.nextRelease.notes).not.toMatch("### Dependencies");
+
+		// ONLY four times.
+		expect(result).toHaveLength(4);
+
+		// Check manifests.
+		expect(require(`${cwd}/packages/a/package.json`)).toMatchObject({
+			peerDependencies: {
+				"msr-test-c": "1.0.0-dev.1",
+			},
+		});
+		expect(require(`${cwd}/packages/b/package.json`)).toMatchObject({
+			dependencies: {
+				"msr-test-a": "1.0.0-dev.1",
+			},
+			devDependencies: {
+				"msr-test-c": "1.0.0-dev.1",
+			},
+		});
+		expect(require(`${cwd}/packages/c/package.json`)).toMatchObject({
+			devDependencies: {
+				"msr-test-b": "1.0.0-dev.1",
+				"msr-test-d": "1.0.0-dev.1",
+			},
+		});
+	});
+	test("Two separate releases (changes in all packages with prereleases)", async () => {
+		const packages = ["packages/a/", "packages/b/", "packages/c/", "packages/d/"];
+
+		// Create Git repo with copy of Yarn workspaces fixture.
+		const cwd = gitInit("master", "release");
+		copyDirectory(`test/fixtures/yarnWorkspaces/`, cwd);
+		const sha1 = gitCommitAll(cwd, "feat: Initial release");
+		gitInitOrigin(cwd, "release");
+		gitPush(cwd);
+
+		let stdout = new WritableStreamBuffer();
+		let stderr = new WritableStreamBuffer();
+
+		// Call multiSemanticRelease()
+		// Doesn't include plugins that actually publish.
+		const multiSemanticRelease = require("../../");
+		let result = await multiSemanticRelease(
+			packages.map((folder) => `${folder}package.json`),
+			{
+				branches: [{ name: "master", prerelease: "dev" }, { name: "release" }],
+			},
+			{ cwd, stdout, stderr }
+		);
+
+		// Add new testing files for a new release.
+		createNewTestingFiles(packages, cwd);
+		const sha = gitCommitAll(cwd, "feat: New releases");
+		gitPush(cwd);
+
+		// Capture output.
+		stdout = new WritableStreamBuffer();
+		stderr = new WritableStreamBuffer();
+
+		// Call multiSemanticRelease() for a second release
+		// Doesn't include plugins that actually publish.
+		result = await multiSemanticRelease(
+			packages.map((folder) => `${folder}package.json`),
+			{
+				branches: [{ name: "master", prerelease: "dev" }, { name: "release" }],
+			},
+			{ cwd, stdout, stderr }
+		);
+
+		// Get stdout and stderr output.
+		const err = stderr.getContentsAsString("utf8");
+		expect(err).toBe(false);
+		const out = stdout.getContentsAsString("utf8");
+		expect(out).toMatch("Started multirelease! Loading 4 packages...");
+		expect(out).toMatch("Loaded package msr-test-a");
+		expect(out).toMatch("Loaded package msr-test-b");
+		expect(out).toMatch("Loaded package msr-test-c");
+		expect(out).toMatch("Loaded package msr-test-d");
+		expect(out).toMatch("Queued 4 packages! Starting release...");
+		expect(out).toMatch("Created tag msr-test-a@1.0.0-dev.2");
+		expect(out).toMatch("Created tag msr-test-b@1.0.0-dev.2");
+		expect(out).toMatch("Created tag msr-test-c@1.0.0-dev.2");
+		expect(out).toMatch("Created tag msr-test-d@1.0.0-dev.2");
+		expect(out).toMatch("Released 4 of 4 packages, semantically!");
+
+		// A.
+		expect(result[0].name).toBe("msr-test-a");
+		expect(result[0].result.lastRelease).toEqual({
+			channels: ["master"],
+			gitHead: sha1,
+			gitTag: "msr-test-a@1.0.0-dev.1",
+			name: "msr-test-a@1.0.0-dev.1",
+			version: "1.0.0-dev.1",
+		});
+		expect(result[0].result.nextRelease).toMatchObject({
+			gitHead: sha,
+			gitTag: "msr-test-a@1.0.0-dev.2",
+			type: "minor",
+			version: "1.0.0-dev.2",
+		});
+		expect(result[0].result.nextRelease.notes).toMatch("# msr-test-a [1.0.0-dev.2]");
+		expect(result[0].result.nextRelease.notes).toMatch("### Features\n\n* New releases");
+		expect(result[0].result.nextRelease.notes).toMatch(
+			"### Dependencies\n\n* **msr-test-c:** upgraded to 1.0.0-dev.2"
+		);
+
+		// B.
+		expect(result[1].name).toBe("msr-test-b");
+		expect(result[1].result.lastRelease).toEqual({
+			channels: ["master"],
+			gitHead: sha1,
+			gitTag: "msr-test-b@1.0.0-dev.1",
+			name: "msr-test-b@1.0.0-dev.1",
+			version: "1.0.0-dev.1",
+		});
+		expect(result[1].result.nextRelease).toMatchObject({
+			gitHead: sha,
+			gitTag: "msr-test-b@1.0.0-dev.2",
+			type: "minor",
+			version: "1.0.0-dev.2",
+		});
+		expect(result[1].result.nextRelease.notes).toMatch("# msr-test-b [1.0.0-dev.2]");
+		expect(result[1].result.nextRelease.notes).toMatch("### Features\n\n* New releases");
+		expect(result[1].result.nextRelease.notes).toMatch(
+			"### Dependencies\n\n* **msr-test-a:** upgraded to 1.0.0-dev.2\n* **msr-test-c:** upgraded to 1.0.0-dev.2"
+		);
+
+		// C.
+		expect(result[2].name).toBe("msr-test-c");
+		expect(result[2].result.lastRelease).toEqual({
+			channels: ["master"],
+			gitHead: sha1,
+			gitTag: "msr-test-c@1.0.0-dev.1",
+			name: "msr-test-c@1.0.0-dev.1",
+			version: "1.0.0-dev.1",
+		});
+		expect(result[2].result.nextRelease).toMatchObject({
+			gitHead: sha,
+			gitTag: "msr-test-c@1.0.0-dev.2",
+			type: "minor",
+			version: "1.0.0-dev.2",
+		});
+		expect(result[2].result.nextRelease.notes).toMatch("# msr-test-c [1.0.0-dev.2]");
+		expect(result[2].result.nextRelease.notes).toMatch("### Features\n\n* New releases");
+		expect(result[2].result.nextRelease.notes).toMatch(
+			"### Dependencies\n\n* **msr-test-b:** upgraded to 1.0.0-dev.2"
+		);
+
+		// D.
+		expect(result[3].name).toBe("msr-test-d");
+		expect(result[3].result.lastRelease).toEqual({
+			channels: ["master"],
+			gitHead: sha1,
+			gitTag: "msr-test-d@1.0.0-dev.1",
+			name: "msr-test-d@1.0.0-dev.1",
+			version: "1.0.0-dev.1",
+		});
+		expect(result[3].result.nextRelease).toMatchObject({
+			gitHead: sha,
+			gitTag: "msr-test-d@1.0.0-dev.2",
+			type: "minor",
+			version: "1.0.0-dev.2",
+		});
+		expect(result[3].result.nextRelease.notes).toMatch("# msr-test-d [1.0.0-dev.2]");
+		expect(result[3].result.nextRelease.notes).toMatch("### Features\n\n* New releases");
+		expect(result[3].result.nextRelease.notes).not.toMatch("### Dependencies");
+
+		// ONLY four times.
+		expect(result).toHaveLength(4);
+
+		// Check manifests.
+		expect(require(`${cwd}/packages/a/package.json`)).toMatchObject({
+			peerDependencies: {
+				"msr-test-c": "1.0.0-dev.2",
+			},
+		});
+		expect(require(`${cwd}/packages/b/package.json`)).toMatchObject({
+			dependencies: {
+				"msr-test-a": "1.0.0-dev.2",
+			},
+			devDependencies: {
+				"msr-test-c": "1.0.0-dev.2",
+			},
+		});
+		expect(require(`${cwd}/packages/c/package.json`)).toMatchObject({
+			devDependencies: {
+				"msr-test-b": "1.0.0-dev.2",
+				"msr-test-d": "1.0.0-dev.2",
 			},
 		});
 	});

--- a/test/lib/updateDeps.test.js
+++ b/test/lib/updateDeps.test.js
@@ -144,17 +144,25 @@ describe("resolveReleaseType()", () => {
 describe("getNextVersion()", () => {
 	// prettier-ignore
 	const cases = [
-		[undefined, "patch", "1.0.0"],
-		["1.0.0", "patch", "1.0.1"],
-		["2.0.0", undefined, "2.0.0"],
+		[undefined, "patch", "1.0.0", null],
+		["1.0.0", "patch", "1.0.1", null],
+		["2.0.0", undefined, "2.0.0", null],
+		[undefined, "patch", "1.0.0-rc.1", "rc"],
+		["1.0.0-rc.0", "minor", "1.0.0-dev.0", "dev"],
+		["1.0.0-dev.0", "major", "1.0.0-dev.1", "dev"],
+		["1.0.0-dev.1", "major", "1.0.0", null],
+		["1.0.0-dev.1", undefined, "1.0.0-dev.1", null],
+		["1.0.0-dev.1", "minor", "1.0.0", null],
+		["1.0.0-dev.1", "patch", "1.0.0", null],
 	]
 
-	cases.forEach(([lastVersion, releaseType, nextVersion]) => {
+	cases.forEach(([lastVersion, releaseType, nextVersion, preRelease]) => {
 		it(`${lastVersion} and ${releaseType} gives ${nextVersion}`, () => {
 			// prettier-ignore
 			expect(getNextVersion({
 				_nextType: releaseType,
-				_lastRelease: {version: lastVersion}
+				_lastRelease: {version: lastVersion},
+				_preRelease: preRelease
 			})).toBe(nextVersion);
 		});
 	});

--- a/test/lib/updateDeps.test.js
+++ b/test/lib/updateDeps.test.js
@@ -167,14 +167,14 @@ describe("getNextVersion()", () => {
 describe("getNextPreVersion()", () => {
 	// prettier-ignore
 	const cases = [
-		[undefined, "patch", "1.0.0-rc.1", "rc"],
-		[undefined, "patch", "1.0.0-rc.1", "rc"],
-		["1.0.0-rc.0", "minor", "1.0.0-dev.0", "dev"],
-		["1.0.0-dev.0", "major", "1.0.0-dev.1", "dev"],
+		[undefined, "patch", "rc", "1.0.0-rc.1"],
+		[undefined, "patch", "rc", "1.0.0-rc.1"],
+		["1.0.0-rc.0", "minor", "dev", "1.0.0-dev.0"],
+		["1.0.0-dev.0", "major", "dev", "1.0.0-dev.1"],
 		
 	]
 
-	cases.forEach(([lastVersion, releaseType, nextVersion, preRelease]) => {
+	cases.forEach(([lastVersion, releaseType, preRelease, nextVersion]) => {
 		it(`${lastVersion} and ${releaseType} gives ${nextVersion}`, () => {
 			// prettier-ignore
 			expect(getNextPreVersion({

--- a/test/lib/updateDeps.test.js
+++ b/test/lib/updateDeps.test.js
@@ -1,4 +1,4 @@
-const { resolveReleaseType, resolveNextVersion, getNextVersion } = require("../../lib/updateDeps");
+const { resolveReleaseType, resolveNextVersion, getNextVersion, getNextPreVersion } = require("../../lib/updateDeps");
 
 describe("resolveNextVersion()", () => {
 	// prettier-ignore
@@ -144,22 +144,40 @@ describe("resolveReleaseType()", () => {
 describe("getNextVersion()", () => {
 	// prettier-ignore
 	const cases = [
-		[undefined, "patch", "1.0.0", null],
-		["1.0.0", "patch", "1.0.1", null],
-		["2.0.0", undefined, "2.0.0", null],
+		[undefined, "patch", "1.0.0"],
+		["1.0.0", "patch", "1.0.1"],
+		["2.0.0", undefined, "2.0.0"],
+		["1.0.0-dev.1", "major", "1.0.0"],
+		["1.0.0-dev.1", undefined, "1.0.0-dev.1"],
+		["1.0.0-dev.1", "minor", "1.0.0"],
+		["1.0.0-dev.1", "patch", "1.0.0"],
+	]
+
+	cases.forEach(([lastVersion, releaseType, nextVersion]) => {
+		it(`${lastVersion} and ${releaseType} gives ${nextVersion}`, () => {
+			// prettier-ignore
+			expect(getNextVersion({
+				_nextType: releaseType,
+				_lastRelease: {version: lastVersion}
+			})).toBe(nextVersion);
+		});
+	});
+});
+
+describe("getNextPreVersion()", () => {
+	// prettier-ignore
+	const cases = [
+		[undefined, "patch", "1.0.0-rc.1", "rc"],
 		[undefined, "patch", "1.0.0-rc.1", "rc"],
 		["1.0.0-rc.0", "minor", "1.0.0-dev.0", "dev"],
 		["1.0.0-dev.0", "major", "1.0.0-dev.1", "dev"],
-		["1.0.0-dev.1", "major", "1.0.0", null],
-		["1.0.0-dev.1", undefined, "1.0.0-dev.1", null],
-		["1.0.0-dev.1", "minor", "1.0.0", null],
-		["1.0.0-dev.1", "patch", "1.0.0", null],
+		
 	]
 
 	cases.forEach(([lastVersion, releaseType, nextVersion, preRelease]) => {
 		it(`${lastVersion} and ${releaseType} gives ${nextVersion}`, () => {
 			// prettier-ignore
-			expect(getNextVersion({
+			expect(getNextPreVersion({
 				_nextType: releaseType,
 				_lastRelease: {version: lastVersion},
 				_preRelease: preRelease


### PR DESCRIPTION
As reported on issue #25, local dependencies weren't pointing to the right pre-release versions with pre-release branches. Added this functionality with:
- Added two branches on the git flow on tests – since only one pre-release branch isn't sufficient for the semantic release kickstart
- Double release flow, checking also if release notes replicated the pre-release versions