### PR TITLE
feat(debug): log manifest deps changes

### DIFF
--- a/lib/updateDeps.js
+++ b/lib/updateDeps.js
@@ -1,6 +1,9 @@
 const { writeFileSync } = require("fs");
-const recognizeFormat = require("./recognizeFormat");
 const semver = require("semver");
+const { isObject, isEqual, transform } = require("lodash");
+const recognizeFormat = require("./recognizeFormat");
+const getManifest = require("./getManifest");
+const debug = require("debug")("msr:updateDeps");
 
 /**
  * Resolve next package version.
@@ -176,8 +179,52 @@ const updateManifestDeps = (pkg) => {
 			throw Error(`Cannot release because dependency ${d.name} has not been released`);
 	});
 
+	if (!auditManifestChanges(manifest, path)) {
+		return;
+	}
+
 	// Write package.json back out.
 	writeFileSync(path, JSON.stringify(manifest, null, indent) + trailingWhitespace);
+};
+
+// https://gist.github.com/Yimiprod/7ee176597fef230d1451
+const difference = (object, base) =>
+	transform(object, (result, value, key) => {
+		if (!isEqual(value, base[key])) {
+			result[key] =
+				isObject(value) && isObject(base[key]) ? difference(value, base[key]) : `${base[key]} → ${value}`;
+		}
+	});
+
+/**
+ * Clarify what exactly was changed in manifest file.
+ * @param {object} actualManifest manifest object
+ * @param {string} path manifest path
+ * @returns {boolean} has changed or not
+ * @internal
+ */
+const auditManifestChanges = (actualManifest, path) => {
+	const oldManifest = getManifest(path);
+	const depScopes = ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"];
+	const changes = depScopes.reduce((res, scope) => {
+		const diff = difference(actualManifest[scope], oldManifest[scope]);
+
+		if (Object.keys(diff).length) {
+			res[scope] = diff;
+		}
+
+		return res;
+	}, {});
+
+	debug(actualManifest.name, path);
+
+	if (Object.keys(changes).length) {
+		debug(changes);
+		return true;
+	}
+
+	debug("no deps changes");
+	return false;
 };
 
 module.exports = {


### PR DESCRIPTION
relates #27

DEBUG=msr:updateDeps
```
2020-12-24T09:37:59.252Z msr:updateDeps msr-test-d /private/var/folders/4x/srw1x58s0m9gstt397scy2300000gn/T/1cf673cb91c40314189349233857cbed/packages/d/package.json
2020-12-24T09:37:59.252Z msr:updateDeps no deps changes
2020-12-24T09:38:01.050Z msr:updateDeps msr-test-c /private/var/folders/4x/srw1x58s0m9gstt397scy2300000gn/T/dc6609bd6c9cccbf3124132f00dc9dbe/packages/c/package.json
2020-12-24T09:38:01.050Z msr:updateDeps {
  devDependencies: { 'msr-test-b': '* → 1.0.0-dev.1', 'msr-test-d': '* → 1.0.0-dev.1' }
}
2020-12-24T09:38:01.368Z msr:updateDeps msr-test-a /private/var/folders/4x/srw1x58s0m9gstt397scy2300000gn/T/dc6609bd6c9cccbf3124132f00dc9dbe/packages/a/package.json
2020-12-24T09:38:01.369Z msr:updateDeps { peerDependencies: { 'msr-test-c': '* → 1.0.0-dev.1' } }
2020-12-24T09:38:01.749Z msr:updateDeps msr-test-b /private/var/folders/4x/srw1x58s0m9gstt397scy2300000gn/T/dc6609bd6c9cccbf3124132f00dc9dbe/packages/b/package.json
2020-12-24T09:38:01.750Z msr:updateDeps {
  dependencies: { 'msr-test-a': '* → 1.0.0-dev.1' },
  devDependencies: { 'msr-test-c': '* → 1.0.0-dev.1' }
}
2020-12-24T09:38:02.083Z msr:updateDeps msr-test-d /private/var/folders/4x/srw1x58s0m9gstt397scy2300000gn/T/dc6609bd6c9cccbf3124132f00dc9dbe/packages/d/package.json
2020-12-24T09:38:02.083Z msr:updateDeps no deps changes
2020-12-24T09:38:03.661Z msr:updateDeps msr-test-c /private/var/folders/4x/srw1x58s0m9gstt397scy2300000gn/T/dc6609bd6c9cccbf3124132f00dc9dbe/packages/c/package.json
2020-12-24T09:38:03.661Z msr:updateDeps {
  devDependencies: {
    'msr-test-b': '1.0.0-dev.1 → 1.0.0-dev.2',
    'msr-test-d': '1.0.0-dev.1 → 1.0.0-dev.2'
  }
}

```