### PR TITLE
fix: bump-up of pre-version

### DIFF
--- a/lib/updateDeps.js
+++ b/lib/updateDeps.js
@@ -40,7 +40,10 @@ const getNextPreVersion = (pkg, tags) => {
 	// 2. Get tags from a branch considering the filters established
 	// TODO: replace {cwd: '.'} with multiContext.cwd
 	if (pkg.name) tagFilters.push(pkg.name);
-	if (!tags || !tags.length) tags = getTags(pkg._branch, { cwd: "." }, tagFilters);
+	if (!tags || !tags.length) {
+		tags = getTags(pkg._branch, { cwd: "." }, tagFilters)
+			.map(tag => pkg.name ? tag.replace(`${pkg.name}@`, '') : tag);
+	}
 
 	const lastPreRelTag = getPreReleaseTag(lastVersion);
 	const isNewPreRelTag = lastPreRelTag && lastPreRelTag !== pkg._preRelease;


### PR DESCRIPTION
Currently when we try to release a new pre-version we receive the error `An error occurred while running semantic-release: TypeError: Invalid Version: <PACKAGE NAME>@<VERSION>`.