### PR TITLE
fix(update-deps): properly resolve next pre-versions

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -5,7 +5,7 @@ const execa = require("execa");
  *
  * @param {String} branch The branch for which to retrieve the tags.
  * @param {Object} [execaOptions] Options to pass to `execa`.
- * @param {Array<String>} filters List of prefixes/sufixes to be checked inside tags.
+ * @param {Array<String>} filters List of string to be checked inside tags.
  *
  * @return {Array<String>} List of git tags.
  * @throws {Error} If the `git` command fails.
@@ -20,7 +20,7 @@ function getTags(branch, execaOptions, filters) {
 
 	if (!filters || !filters.length) return tags;
 
-	const validateSubstr = (t, f) => !!f.find((v) => t.includes(v));
+	const validateSubstr = (t, f) => f.every((v) => t.includes(v));
 
 	return tags.filter((tag) => validateSubstr(tag, filters));
 }

--- a/lib/updateDeps.js
+++ b/lib/updateDeps.js
@@ -23,6 +23,16 @@ const getNextVersion = (pkg) => {
 };
 
 /**
+ * Resolve the package version from a tag
+ *
+ * @param {Package} pkg Package object.
+ * @param {string} tag The tag containing the version to resolve
+ * @returns {string} The version of the package
+ * @internal
+ */
+const getVersionFromTag = (pkg, tag) => (pkg.name ? tag.replace(`${pkg.name}@`, "") : tag);
+
+/**
  * Resolve next package version on prereleases.
  *
  * @param {Package} pkg Package object.
@@ -38,20 +48,27 @@ const getNextPreVersion = (pkg, tags) => {
 	// Extract tags:
 	// 1. Set filter to extract only package tags
 	// 2. Get tags from a branch considering the filters established
+	// 3. Resolve the versions from the tags
 	// TODO: replace {cwd: '.'} with multiContext.cwd
 	if (pkg.name) tagFilters.push(pkg.name);
 	if (!tags || !tags.length) {
-		tags = getTags(pkg._branch, { cwd: "." }, tagFilters).map((tag) =>
-			pkg.name ? tag.replace(`${pkg.name}@`, "") : tag
-		);
+		tags = getTags(pkg._branch, { cwd: "." }, tagFilters);
 	}
 
 	const lastPreRelTag = getPreReleaseTag(lastVersion);
 	const isNewPreRelTag = lastPreRelTag && lastPreRelTag !== pkg._preRelease;
 
-	return isNewPreRelTag || !lastVersion
-		? `1.0.0-${pkg._preRelease}.1`
-		: _nextPreVersionCases(tags, lastVersion, pkg._nextType, pkg._preRelease);
+	const versionToSet =
+		isNewPreRelTag || !lastVersion
+			? `1.0.0-${pkg._preRelease}.1`
+			: _nextPreVersionCases(
+					tags.map((tag) => getVersionFromTag(pkg, tag)),
+					lastVersion,
+					pkg._nextType,
+					pkg._preRelease
+			  );
+
+	return versionToSet;
 };
 
 /**

--- a/test/lib/updateDeps.test.js
+++ b/test/lib/updateDeps.test.js
@@ -179,8 +179,8 @@ describe("getNextPreVersion()", () => {
 		[null, "patch", "rc", [], "1.0.0-rc.1"],
 		["1.0.0-rc.0", "minor", "dev", [], "1.0.0-dev.1"],
 		["1.0.0-dev.0", "major", "dev", [], "1.0.0-dev.1"],
-		["1.0.0-dev.0", "major", "dev", ["1.0.0-dev.1"], "1.0.0-dev.2"],
-		["1.0.0-dev.0", "major", "dev", ["1.0.0-dev.1", "1.0.1-dev.0"], "1.0.1-dev.1"],
+		["1.0.0-dev.0", "major", "dev", ["testing-package@1.0.0-dev.1"], "1.0.0-dev.2"],
+		["1.0.0-dev.0", "major", "dev", ["testing-package@1.0.0-dev.1", "1.0.1-dev.0"], "1.0.1-dev.1"],
 		["11.0.0", "major", "beta", [], "12.0.0-beta.1"],
 		["1.0.0", "minor", "beta", [], "1.1.0-beta.1"],
 		["1.0.0", "patch", "beta", [], "1.0.1-beta.1"],
@@ -196,7 +196,8 @@ describe("getNextPreVersion()", () => {
 					_nextType: releaseType,
 					_lastRelease: {version: lastVersion},
 					_preRelease: preRelease,
-					_branch: "master",
+          _branch: "master",
+          name: "testing-package"
 				},
 				lastTags
 			)).toBe(nextVersion);


### PR DESCRIPTION
Fix following this [PR](https://github.com/qiwi/multi-semantic-release/pull/38).
The first PR wasn't fixing the issue because the `filters` on `getTags` was only checking that one filter was matching the tag. Because of that we were considering every pre-version tags, even the one related other packages. 