### PR TITLE
feat: allow to run prepare steps sequentially

### DIFF
--- a/lib/createInlinePluginCreator.js
+++ b/lib/createInlinePluginCreator.js
@@ -181,7 +181,7 @@ function createInlinePluginCreator(packages, multiContext, synchronizer, flags) 
 		};
 
 		const prepare = async (pluginOptions, context) => {
-			if (pkg.options.sequentialPrepare) {
+			if (flags.sequentialPrepare) {
 				debug(debugPrefix, "waiting local dependencies preparation");
 				await waitLocalDeps("_prepared", pkg);
 			}

--- a/lib/createInlinePluginCreator.js
+++ b/lib/createInlinePluginCreator.js
@@ -17,7 +17,7 @@ const { updateManifestDeps, resolveReleaseType } = require("./updateDeps");
 function createInlinePluginCreator(packages, multiContext, synchronizer, flags) {
 	// Vars.
 	const { cwd } = multiContext;
-	const { todo, waitFor, waitForAll, emit, getLucky } = synchronizer;
+	const { todo, waitFor, waitForAll, emit, getLucky, waitLocalDeps } = synchronizer;
 
 	/**
 	 * Create an inline plugin for an individual package in a multirelease.
@@ -181,6 +181,11 @@ function createInlinePluginCreator(packages, multiContext, synchronizer, flags) 
 		};
 
 		const prepare = async (pluginOptions, context) => {
+			if (pkg.options.sequentialPrepare) {
+				debug(debugPrefix, "waiting local dependencies preparation");
+				await waitLocalDeps("_prepared", pkg);
+			}
+
 			// Wait until the current pkg is ready to be tagged
 			getLucky("_readyForTagging", pkg);
 			await waitFor("_readyForTagging", pkg);
@@ -192,6 +197,7 @@ function createInlinePluginCreator(packages, multiContext, synchronizer, flags) 
 			pkg._prepared = true;
 
 			debug(debugPrefix, "prepared");
+			emit("_prepared", pkg);
 
 			return res;
 		};

--- a/lib/getSynchronizer.js
+++ b/lib/getSynchronizer.js
@@ -74,6 +74,13 @@ const getSynchronizer = (packages) => {
 		getLucky[probe] = emit(probe, pkg);
 	};
 
+	// Wait that all local deps passes the probe
+	const waitLocalDeps = (probe, pkg) => {
+		return Promise.all(pkg.localDeps.map((d) => waitFor(probe, d))).then(() => {
+			debug(`[${pkg.name}]`, `all local dependencies emitted ${probe}`);
+		});
+	};
+
 	return {
 		ee,
 		emit,
@@ -82,6 +89,7 @@ const getSynchronizer = (packages) => {
 		waitFor,
 		waitForAll,
 		getLucky,
+		waitLocalDeps,
 	};
 };
 

--- a/lib/isCyclicProject.js
+++ b/lib/isCyclicProject.js
@@ -1,0 +1,12 @@
+/**
+ * Detect if there is a cyclic dependency tree between the packages
+ * @param {Array<Package>} pkgs Array of package object
+ * @returns {boolean} True if there are a cyclic dependency
+ */
+const isCyclicProject = (pkgs) => {
+	return pkgs.some((pkg) =>
+		pkg.localDeps.some((dep) => dep.localDeps.some((nestedDep) => nestedDep.name === pkg.name))
+	);
+};
+
+module.exports = isCyclicProject;

--- a/lib/multiSemanticRelease.js
+++ b/lib/multiSemanticRelease.js
@@ -1,7 +1,7 @@
 const { dirname } = require("path");
 const semanticRelease = require("semantic-release");
 const { uniq } = require("lodash");
-const { check } = require("./blork");
+const { check, ValueError } = require("./blork");
 const getLogger = require("./getLogger");
 const getSynchronizer = require("./getSynchronizer");
 const getConfig = require("./getConfig");
@@ -10,6 +10,7 @@ const getManifest = require("./getManifest");
 const cleanPath = require("./cleanPath");
 const RescopedStream = require("./RescopedStream");
 const createInlinePluginCreator = require("./createInlinePluginCreator");
+const isCyclicProject = require("./isCyclicProject");
 
 /**
  * The multirelease context.
@@ -76,6 +77,11 @@ async function multiSemanticRelease(
 
 		logger.success(`Loaded package ${pkg.name}`);
 	});
+
+	if (flags.sequentialPrepare && isCyclicProject(packages)) {
+		logger.error("There is a cyclic dependency in packages while the sequentialPrepare is enabled");
+		throw new ValueError("can't have cyclic with sequentialPrepare option");
+	}
 
 	logger.complete(`Queued ${packages.length} packages! Starting release...`);
 

--- a/test/lib/isCyclicProject.test.js
+++ b/test/lib/isCyclicProject.test.js
@@ -1,0 +1,42 @@
+const isCyclicProject = require("../../lib/isCyclicProject");
+
+// Tests.
+describe("isCyclicProject()", () => {
+	const pkgA = {
+		name: "pkgA",
+		localDeps: [],
+	};
+
+	const pkgB = {
+		name: "pkgB",
+		localDeps: [],
+	};
+
+	const pkgC = {
+		name: "pkgC",
+		localDeps: [pkgB],
+	};
+
+	const pkgE = {
+		name: "pkgD",
+		localDeps: [],
+	};
+
+	const pkgD = {
+		name: "pkgD",
+		localDeps: [pkgE],
+	};
+
+	pkgE.localDeps = [pkgD];
+
+	test("With independent packages", () => {
+		expect(isCyclicProject([pkgA, pkgB])).toBeFalsy();
+	});
+	test("With simple chain", () => {
+		expect(isCyclicProject([pkgB, pkgC])).toBeFalsy();
+	});
+
+	test("With cyclic dependency", () => {
+		expect(isCyclicProject([pkgD, pkgD])).toBeTruthy();
+	});
+});

--- a/test/lib/multiSemanticRelease.test.js
+++ b/test/lib/multiSemanticRelease.test.js
@@ -1,4 +1,6 @@
+const { ValueError } = require("blork");
 const { writeFileSync } = require("fs");
+const { resolve } = require("path");
 const path = require("path");
 const { Signale } = require("signale");
 const { WritableStreamBuffer } = require("stream-buffers");
@@ -16,6 +18,7 @@ const {
 
 // Clear mocks before tests.
 beforeEach(() => {
+	jest.setTimeout(50000);
 	jest.clearAllMocks(); // Clear all mocks.
 	require.cache = {}; // Clear the require cache so modules are loaded fresh.
 });
@@ -352,6 +355,7 @@ describe("multiSemanticRelease()", () => {
 			},
 		});
 	});
+
 	test("Two separate releases (release to prerelease)", async () => {
 		const packages = ["packages/c/", "packages/d/"];
 
@@ -797,6 +801,111 @@ describe("multiSemanticRelease()", () => {
 			},
 		});
 	});
+
+	test("Changes in child packages with sequentialPrepare", async () => {
+		const mockPrepare = jest.fn();
+		// Create Git repo.
+		const cwd = gitInit();
+		// Initial commit.
+		copyDirectory(`test/fixtures/yarnWorkspaces2Packages/`, cwd);
+		const sha1 = gitCommitAll(cwd, "feat: Initial release");
+		gitTag(cwd, "msr-test-c@1.0.0");
+		gitTag(cwd, "msr-test-d@1.0.0");
+		// Second commit.
+		writeFileSync(`${cwd}/packages/d/aaa.txt`, "AAA");
+		const sha2 = gitCommitAll(cwd, "feat(aaa): Add missing text file");
+		const url = gitInitOrigin(cwd);
+		gitPush(cwd);
+
+		// Capture output.
+		const stdout = new WritableStreamBuffer();
+		const stderr = new WritableStreamBuffer();
+
+		// Call multiSemanticRelease()
+		// Doesn't include plugins that actually publish.
+		const multiSemanticRelease = require("../../");
+		const result = await multiSemanticRelease(
+			[`packages/c/package.json`, `packages/d/package.json`],
+			{
+				plugins: [
+					{
+						// Ensure that msr-test-c is always ready before msr-test-d
+						verify: (_, { lastRelease: { name } }) =>
+							new Promise((resolvePromise) => {
+								if (name.split("@")[0] === "msr-test-c") {
+									resolvePromise();
+								}
+
+								setTimeout(resolvePromise, 5000);
+							}),
+					},
+					{
+						prepare: (_, { lastRelease: { name } }) => {
+							mockPrepare(name.split("@")[0]);
+						},
+					},
+				],
+			},
+			{ cwd, stdout, stderr },
+			{ deps: {}, dryRun: false, sequentialPrepare: true }
+		);
+
+		expect(mockPrepare).toHaveBeenNthCalledWith(1, "msr-test-d");
+		expect(mockPrepare).toHaveBeenNthCalledWith(2, "msr-test-c");
+
+		// Get stdout and stderr output.
+		const err = stderr.getContentsAsString("utf8");
+		expect(err).toBe(false);
+		const out = stdout.getContentsAsString("utf8");
+		expect(out).toMatch("Started multirelease! Loading 2 packages...");
+		expect(out).toMatch("Loaded package msr-test-c");
+		expect(out).toMatch("Loaded package msr-test-d");
+		expect(out).toMatch("Queued 2 packages! Starting release...");
+		expect(out).toMatch("Created tag msr-test-d@1.1.0");
+		expect(out).toMatch("Created tag msr-test-c@1.0.1");
+		expect(out).toMatch("Released 2 of 2 packages, semantically!");
+
+		// C.
+		expect(result[0].name).toBe("msr-test-c");
+		expect(result[0].result.lastRelease).toMatchObject({
+			gitHead: sha1,
+			gitTag: "msr-test-c@1.0.0",
+			version: "1.0.0",
+		});
+		expect(result[0].result.nextRelease).toMatchObject({
+			gitHead: sha2,
+			gitTag: "msr-test-c@1.0.1",
+			type: "patch",
+			version: "1.0.1",
+		});
+
+		// D.
+		expect(result[1].name).toBe("msr-test-d");
+		expect(result[1].result.lastRelease).toEqual({
+			channels: [null],
+			gitHead: sha1,
+			gitTag: "msr-test-d@1.0.0",
+			name: "msr-test-d@1.0.0",
+			version: "1.0.0",
+		});
+		expect(result[1].result.nextRelease).toMatchObject({
+			gitHead: sha2,
+			gitTag: "msr-test-d@1.1.0",
+			type: "minor",
+			version: "1.1.0",
+		});
+
+		// ONLY three times.
+		expect(result[2]).toBe(undefined);
+
+		// Check manifests.
+		expect(require(`${cwd}/packages/c/package.json`)).toMatchObject({
+			dependencies: {
+				"msr-test-d": "1.1.0",
+			},
+		});
+	});
+
 	test("Changes in some packages (sequential-init)", async () => {
 		// Create Git repo.
 		const cwd = gitInit();
@@ -828,8 +937,7 @@ describe("multiSemanticRelease()", () => {
 				`packages/a/package.json`,
 			],
 			{},
-			{ cwd, stdout, stderr },
-			{ sequentialInit: true, deps: {} }
+			{ cwd, stdout, stderr }
 		);
 
 		// Check manifests.
@@ -1028,6 +1136,39 @@ describe("multiSemanticRelease()", () => {
 		await expect(r6).rejects.toBeInstanceOf(SyntaxError);
 		await expect(r6).rejects.toMatchObject({
 			message: expect.stringMatching("Package peerDependencies must be object"),
+		});
+	});
+
+	test("ValueError if sequentialPrepare is enabled on a cyclic project", async () => {
+		// Create Git repo with copy of Yarn workspaces fixture.
+		const cwd = gitInit();
+		copyDirectory(`test/fixtures/yarnWorkspaces/`, cwd);
+		const sha = gitCommitAll(cwd, "feat: Initial release");
+		const url = gitInitOrigin(cwd);
+		gitPush(cwd);
+
+		// Capture output.
+		const stdout = new WritableStreamBuffer();
+		const stderr = new WritableStreamBuffer();
+
+		// Call multiSemanticRelease()
+		// Doesn't include plugins that actually publish.
+		const multiSemanticRelease = require("../../");
+		const result = multiSemanticRelease(
+			[
+				`packages/a/package.json`,
+				`packages/b/package.json`,
+				`packages/c/package.json`,
+				`packages/d/package.json`,
+			],
+			{},
+			{ cwd, stdout, stderr },
+			{ sequentialPrepare: true, deps: {} }
+		);
+
+		await expect(result).rejects.toBeInstanceOf(ValueError);
+		await expect(result).rejects.toMatchObject({
+			message: expect.stringMatching("can't have cyclic with sequentialPrepare option"),
 		});
 	});
 });


### PR DESCRIPTION
This can be useful in the case where we must build a whole package in the prepare step.
In my specific case we use multi-semantic-release to publish some common types and a Docker image. In the prepare step we run a `docker build` in which we need to re-install the dependencies.

Because sometimes the prepare step is not over in the type package the build result in an error because the inlinePlugin started writing half of the package.json to update the dependencies version.