### PR TITLE
fix(sequential-prepare): do not wait forever when a child package has no change

### DIFF
--- a/lib/createInlinePluginCreator.js
+++ b/lib/createInlinePluginCreator.js
@@ -112,6 +112,11 @@ function createInlinePluginCreator(packages, multiContext, synchronizer, flags) 
 			debug(debugPrefix, "commits analyzed");
 			debug(debugPrefix, `release type: ${pkg._nextType}`);
 
+			// if the package won't be released consider it as prepared
+			if (!pkg._nextType) {
+				emit("_prepared", pkg);
+			}
+
 			// Return type.
 			return pkg._nextType;
 		};


### PR DESCRIPTION
We spotted an error.
With the option "sequential-prepare", if a package A depends on package B and there a changes only in package A semrel will never end because it will wait for package B to finish its "prepare" step which will never run.