### PR TITLE
feat: add --tag-format flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ CLI flag options:
 	--ignore-packages  Packages list to be ignored on bumping process (append to the ones that already exist at package.json workspaces)
     --deps.bump Define deps version updating rule. Allowed: override, satisfy, inherit.
 		--deps.release Define release type for dependent package if any of its deps changes. Supported values: patch, minor, major, inherit.
-    --tag-version-format Format to use for the version number applied to tag names. Default: "@${version}" generates "package-name@1.0.0"
+    --tag-format Format to use for creating tag names. Should include "name" and "version" vars. Default: "${name}@${version}" generates "package-name@1.0.0"
     --help Help info.
 
   Examples

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ CLI flag options:
 	--ignore-packages  Packages list to be ignored on bumping process (append to the ones that already exist at package.json workspaces)
     --deps.bump Define deps version updating rule. Allowed: override, satisfy, inherit.
 		--deps.release Define release type for dependent package if any of its deps changes. Supported values: patch, minor, major, inherit.
+    --tag-version-format Format to use for the version number applied to tag names. Default: "@${version}" generates "package-name@1.0.0"
     --help Help info.
 
   Examples

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -17,6 +17,7 @@ const cli = meow(
     --deps.bump Define deps version updating rule. Allowed: override, satisfy, inherit.
     --deps.release Define release type for dependent package if any of its deps changes. Supported values: patch, minor, major, inherit.
     --ignore-packages  Packages' list to be ignored on bumping process
+    --tag-version-format Format to use for the version number applied to tag names. Default: "@\${version}" generates "package-name@1.0.0"
     --help Help info.
 
   Examples
@@ -48,6 +49,10 @@ const cli = meow(
 			},
 			ignorePackages: {
 				type: "string",
+			},
+			tagVersionFormat: {
+				type: "string",
+				default: "@${version}",
 			},
 			dryRun: {
 				type: "boolean",

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -17,7 +17,7 @@ const cli = meow(
     --deps.bump Define deps version updating rule. Allowed: override, satisfy, inherit.
     --deps.release Define release type for dependent package if any of its deps changes. Supported values: patch, minor, major, inherit.
     --ignore-packages  Packages' list to be ignored on bumping process
-    --tag-version-format Format to use for the version number applied to tag names. Default: "@\${version}" generates "package-name@1.0.0"
+    --tag-format Format to use for creating tag names. Should include "name" and "version" vars. Default: "\${name}@\${version}" generates "package-name@1.0.0"
     --help Help info.
 
   Examples
@@ -50,9 +50,9 @@ const cli = meow(
 			ignorePackages: {
 				type: "string",
 			},
-			tagVersionFormat: {
+			tagFormat: {
 				type: "string",
-				default: "@${version}",
+				default: "${name}@${version}",
 			},
 			dryRun: {
 				type: "boolean",

--- a/lib/multiSemanticRelease.js
+++ b/lib/multiSemanticRelease.js
@@ -1,6 +1,6 @@
 const { dirname } = require("path");
 const semanticRelease = require("semantic-release");
-const { uniq } = require("lodash");
+const { uniq, template } = require("lodash");
 const { check, ValueError } = require("./blork");
 const getLogger = require("./getLogger");
 const getSynchronizer = require("./getSynchronizer");
@@ -189,7 +189,13 @@ async function releasePackage(pkg, createInlinePlugin, multiContext, flags) {
 	// Add the package name into tagFormat.
 	// Thought about doing a single release for the tag (merging several packages), but it's impossible to prevent Github releasing while allowing NPM to continue.
 	// It'd also be difficult to merge all the assets into one release without full editing/overriding the plugins.
-	options.tagFormat = name + (flags.tagVersionFormat || "@${version}");
+	const tagFormatCtx = {
+		name,
+		version: "${version}",
+	};
+
+	const tagFormatDefault = "${name}@${version}";
+	options.tagFormat = template(flags.tagFormat || tagFormatDefault)(tagFormatCtx);
 
 	// This options are needed for plugins that do not rely on `pluginOptions` and extract them independently.
 	options._pkgOptions = pkgOptions;

--- a/lib/multiSemanticRelease.js
+++ b/lib/multiSemanticRelease.js
@@ -189,7 +189,7 @@ async function releasePackage(pkg, createInlinePlugin, multiContext, flags) {
 	// Add the package name into tagFormat.
 	// Thought about doing a single release for the tag (merging several packages), but it's impossible to prevent Github releasing while allowing NPM to continue.
 	// It'd also be difficult to merge all the assets into one release without full editing/overriding the plugins.
-	options.tagFormat = name + "@${version}";
+	options.tagFormat = name + (flags.tagVersionFormat || "@${version}");
 
 	// This options are needed for plugins that do not rely on `pluginOptions` and extract them independently.
 	options._pkgOptions = pkgOptions;

--- a/test/lib/multiSemanticRelease.test.js
+++ b/test/lib/multiSemanticRelease.test.js
@@ -1301,7 +1301,7 @@ describe("multiSemanticRelease()", () => {
 			[`packages/a/package.json`],
 			{},
 			{ cwd, stdout, stderr },
-			{ tagVersionFormat: "/${version}", deps: {} }
+			{ tagFormat: "${name}/${version}", deps: {} }
 		);
 
 		// Get stdout and stderr output.

--- a/test/lib/multiSemanticRelease.test.js
+++ b/test/lib/multiSemanticRelease.test.js
@@ -1283,4 +1283,31 @@ describe("multiSemanticRelease()", () => {
 			message: expect.stringMatching("can't have cyclic with sequentialPrepare option"),
 		});
 	});
+
+	test("Generated tag with custom version format", async () => {
+		// Create Git repo with copy of Yarn workspaces fixture.
+		const cwd = await gitInit();
+		copyDirectory(`test/fixtures/yarnWorkspaces/`, cwd);
+		await gitCommitAll(cwd, "feat: Initial release");
+		await gitInitOrigin(cwd);
+		await gitPush(cwd);
+
+		// Capture output.
+		const stdout = new WritableStreamBuffer();
+		const stderr = new WritableStreamBuffer();
+
+		const multiSemanticRelease = require("../../");
+		await multiSemanticRelease(
+			[`packages/a/package.json`],
+			{},
+			{ cwd, stdout, stderr },
+			{ tagVersionFormat: "/${version}", deps: {} }
+		);
+
+		// Get stdout and stderr output.
+		const err = stderr.getContentsAsString("utf8");
+		expect(err).toBe(false);
+		const out = stdout.getContentsAsString("utf8");
+		expect(out).toMatch("Created tag msr-test-a/1.0.0");
+	});
 });


### PR DESCRIPTION
Adds a flag to modify the version format used to create `tagFormat`.

### Use Case
I'm attempting to use the generated tags to publish Docker images and Docker tags cannot contain an `@`.