### PR TITLE
fix: fix globbing on Windows

### DIFF
--- a/lib/getPackagePaths.js
+++ b/lib/getPackagePaths.js
@@ -29,7 +29,7 @@ function getPackagePaths(cwd, ignorePackages = null) {
 	}
 
 	// remove cwd from results
-	const packages = workspace.packages.map((p) => path.relative(cwd, p.dir));
+	const packages = workspace.packages.map((p) => path.relative(cwd, p.dir).replace(/\\/g, '/'));
 
 	// If packages to be ignored come from CLI, we need to combine them with the ones from manifest workspaces
 	if (Array.isArray(ignorePackages)) packages.push(...ignorePackages.map((p) => `!${p}`));

--- a/lib/getPackagePaths.js
+++ b/lib/getPackagePaths.js
@@ -1,5 +1,6 @@
 const getManifest = require("./getManifest");
 const glob = require("./glob");
+const { slash } = require("./utils");
 const path = require("path");
 const { getPackagesSync } = require("@manypkg/get-packages");
 
@@ -29,7 +30,7 @@ function getPackagePaths(cwd, ignorePackages = null) {
 	}
 
 	// remove cwd from results
-	const packages = workspace.packages.map((p) => path.relative(cwd, p.dir).replace(/\\/g, "/"));
+	const packages = workspace.packages.map((p) => slash(path.relative(cwd, p.dir)));
 
 	// If packages to be ignored come from CLI, we need to combine them with the ones from manifest workspaces
 	if (Array.isArray(ignorePackages)) packages.push(...ignorePackages.map((p) => `!${p}`));

--- a/lib/getPackagePaths.js
+++ b/lib/getPackagePaths.js
@@ -29,7 +29,7 @@ function getPackagePaths(cwd, ignorePackages = null) {
 	}
 
 	// remove cwd from results
-	const packages = workspace.packages.map((p) => path.relative(cwd, p.dir).replace(/\\/g, '/'));
+	const packages = workspace.packages.map((p) => path.relative(cwd, p.dir).replace(/\\/g, "/"));
 
 	// If packages to be ignored come from CLI, we need to combine them with the ones from manifest workspaces
 	if (Array.isArray(ignorePackages)) packages.push(...ignorePackages.map((p) => `!${p}`));

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -61,7 +61,7 @@ function slash(path) {
 		return path;
 	}
 
-	return path.replace(/\\/g, '/');
+	return path.replace(/\\/g, "/");
 }
 
 module.exports = {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -52,9 +52,22 @@ function getLatestVersion(versions, withPrerelease) {
 	return versions.filter((version) => withPrerelease || !prerelease(version)).sort(rcompare)[0];
 }
 
+// https://github.com/sindresorhus/slash/blob/b5cdd12272f94cfc37c01ac9c2b4e22973e258e5/index.js#L1
+function slash(path) {
+	const isExtendedLengthPath = /^\\\\\?\\/.test(path);
+	const hasNonAscii = /[^\u0000-\u0080]+/.test(path); // eslint-disable-line no-control-regex
+
+	if (isExtendedLengthPath || hasNonAscii) {
+		return path;
+	}
+
+	return path.replace(/\\/g, '/');
+}
+
 module.exports = {
 	tagsToVersions,
 	getHighestVersion,
 	getLowestVersion,
 	getLatestVersion,
+	slash,
 };


### PR DESCRIPTION
Fix this well-known issue on Windows... upstream: https://github.com/sindresorhus/globby/issues/155

Passing Windows's backslash to globby/fast-glob will cause an empty return for [workspacePackages](https://github.com/qiwi/multi-semantic-release/blob/d83a6a729f31c8a1fcbd2720797b673781828bd2/lib/getPackagePaths.js#L38).

https://github.com/qiwi/multi-semantic-release/blob/d83a6a729f31c8a1fcbd2720797b673781828bd2/lib/getPackagePaths.js#L38

Which leads to an error of `package.json: Project must contain one or more workspace-packages`.



