### PR TITLE
feat: enable `sequentialPrepare` flag by default

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -32,6 +32,7 @@ const cli = meow(
 			},
 			sequentialPrepare: {
 				type: "boolean",
+				default: true,
 			},
 			firstParent: {
 				type: "boolean",
@@ -63,7 +64,16 @@ const cli = meow(
 
 const processFlags = (flags) => {
 	return toPairs(flags).reduce((m, [k, v]) => {
-		if (k === "ignorePackages" && v) return set(m, k, v.split(","));
+		if (k === "ignorePackages" && v) {
+			return set(m, k, v.split(","));
+		}
+
+		// FIXME Smth wrong with negate parser.
+		if (flags[`no${k[0].toUpperCase()}${k.slice(1)}`]) {
+			flags[k] = false;
+			return set(m, k, false);
+		}
+
 		return set(m, k, v);
 	}, {});
 };

--- a/test/bin/cli.test.js
+++ b/test/bin/cli.test.js
@@ -25,7 +25,7 @@ describe("multi-semantic-release CLI", () => {
 		const filepath = `${__dirname}/../../bin/cli.js`;
 
 		// Run via command line.
-		const out = (await execa("node", [filepath], { cwd })).stdout;
+		const out = (await execa("node", [filepath, "-- --no-sequential-prepare"], { cwd })).stdout;
 		expect(out).toMatch("Started multirelease! Loading 4 packages...");
 		expect(out).toMatch("Released 4 of 4 packages, semantically!");
 	});


### PR DESCRIPTION
BREAKING CHANGE: sequentialPrepare is set to true, to disable pass `--no-sequential-prepare` option