### PR TITLE
feat: added declarative config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,29 +22,80 @@ yarn add @qiwi/multi-semantic-release --dev
 multi-semantic-release
 ```
 
-CLI flag options:
+## Configuring Multi-Semantic-Release
 
-```sh
-  Options
-    --dry-run Dry run mode.
-    --debug Output debugging information.
-    --sequential-init  Avoid hypothetical concurrent initialization collisions.
-    --first-parent Apply commit filtering to current branch only.
-    --ignore-private Exclude private packages. True by default.
-    --ignore-packages  Packages list to be ignored on bumping process (append to the ones that already exist at package.json workspaces)
-    --deps.bump Define deps version updating rule. Allowed: override, satisfy, inherit.
-    --deps.release Define release type for dependent package if any of its deps changes. Supported values: patch, minor, major, inherit.
-    --deps.prefix Optional prefix to be attached to the next version if `--deps.bump` set to `override`. Supported values: '^' | '~'` | '' (empty string, default).
-    --tag-format Format to use for creating tag names. Should include "name" and "version" vars. Default: "${name}@${version}" generates "package-name@1.0.0"
-    --help Help info.
+multi-semantic-release can be configured a number of ways:
 
-  Examples
-    $ multi-semantic-release --debug
-	$ multi-semantic-release --deps.bump=satisfy --deps.release=patch
-	$ multi-semantic-release --ignore-packages=packages/a/**,packages/b/**
+* A `.multi-releaserc` file, written in YAML or JSON, with optional extensions: `.yaml`/ `.yml`/ `.json`/ `.js`
+* A `multi-release.config.js` file that exports an object
+* A `multi-release` key in the workspace root package.json
+
+Alternatively some options may be set via CLI flags.
+
+**Note:** CLI arguments take precedence over options configured in the configuration file.
+
+### Options
+
+| Option | Type | CLI Flag | Description |
+| ------ | ---- | -------- | ----------- |
+| dryRun | `boolean` | `--dry-run` | Dry run mode. |
+| debug | `boolean` | `--debug` | Output debugging information. |
+| extends | `String \| Array` | N/A | List of modules or file paths containing a shareable configuration. If multiple shareable configurations are set, they will be imported in the order defined with each configuration option taking precedence over the options defined in the previous. |
+| sequentialInit | `boolean` | `--sequential-init` | Avoid hypothetical concurrent initialization collisions. |
+| sequentialPrepare | `boolean` | `--sequential-prepare` | Avoid hypothetical concurrent preparation collisions. **True by default.** |
+| firstParent | `boolean` | `--first-parent` | Apply commit filtering to current branch only. |
+| ignorePrivate | `boolean` | `--ignore-private` | Exclude private packages. **True by default.** |
+| ignorePackages | `String \| Array` | `--ignore-packages` | Packages list to be ignored on bumping process (appended to the ones that already exist at package.json workspaces). If using the CLI flag, supply a comma seperated list of strings. |
+| tagFormat | `String` | `--tag-format` | Format to use when creating tag names. Should include "name" and "version" vars. Default: `"${name}@${version}"` which generates "package-name@1.0.0" |
+| deps | `Object` | N/A | Depedency handling, see below for possible values. |
+
+### `deps` Options
+
+| Option | Type | CLI Flag | Description |
+| ------ | ---- | -------- | ----------- |
+| bump | `override \| satisfy \| inherit` | `--deps.bump` | Define deps version updating rule. Allowed: override, satisfy, inherit. **`override` by default.** |
+| release | `patch \| minor \| major \| inherit` | `--deps.release` | Define release type for dependent package if any of its deps changes. Supported values: patch, minor, major, inherit. **`patch` by default** |
+| prefix | `'^' \| '~' \| ''` | `--deps.prefix` | Optional prefix to be attached to the next version if `bump` is set to `override`. **`''` by default**. |
+
+### Examples
+
+* Via multi-release key in the project's package.json file:
+
+```json
+{
+	"multi-release": {
+		"ignorePackages": [
+			"!packages/b/**",
+			"!packages/c/**"
+		],
+		"deps": {
+			"bump": "inherit"
+		}
+	}
+}
 ```
 
-## Configuration
+* Via `.multi-releaserc` file:
+
+```json
+{
+	"ignorePackages": [
+		"!packages/b/**",
+		"!packages/c/**"
+	],
+	"deps": {
+		"bump": "inherit"
+	}
+}
+```
+
+* Via CLI:
+
+```sh
+$ multi-semantic-release --ignore-packages=packages/a/**,packages/b/** --deps.bump=inherit
+```
+
+## Configuring Semantic-Release
 **MSR** requires **semrel** config to be added [in any supported format](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#configuration) for each package or/and declared in repo root (`globalConfig` is extremely useful if all the modules have the same strategy of release).  
 NOTE config resolver joins `globalConfig` and `packageConfig` during execution.
 ```javascript

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -35,47 +35,6 @@ const cli = meow(
 			const argvStart = process.argv.includes("--") ? process.argv.indexOf("--") + 1 : 2;
 			return process.argv.slice(argvStart);
 		},
-		flags: {
-			sequentialInit: {
-				type: "boolean",
-			},
-			sequentialPrepare: {
-				type: "boolean",
-				default: true,
-			},
-			firstParent: {
-				type: "boolean",
-			},
-			debug: {
-				type: "boolean",
-			},
-			"deps.bump": {
-				type: "string",
-				default: "override",
-			},
-			"deps.release": {
-				type: "string",
-				default: "patch",
-			},
-			"deps.prefix": {
-				type: "string",
-				default: "",
-			},
-			ignorePrivate: {
-				type: "boolean",
-				default: true,
-			},
-			ignorePackages: {
-				type: "string",
-			},
-			tagFormat: {
-				type: "string",
-				default: "${name}@${version}",
-			},
-			dryRun: {
-				type: "boolean",
-			},
-		},
 	}
 );
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -35,6 +35,42 @@ const cli = meow(
 			const argvStart = process.argv.includes("--") ? process.argv.indexOf("--") + 1 : 2;
 			return process.argv.slice(argvStart);
 		},
+		booleanDefault: undefined,
+		flags: {
+			sequentialInit: {
+				type: "boolean",
+			},
+			sequentialPrepare: {
+				type: "boolean",
+			},
+			firstParent: {
+				type: "boolean",
+			},
+			debug: {
+				type: "boolean",
+			},
+			"deps.bump": {
+				type: "string",
+			},
+			"deps.release": {
+				type: "string",
+			},
+			"deps.prefix": {
+				type: "string",
+			},
+			ignorePrivate: {
+				type: "boolean",
+			},
+			ignorePackages: {
+				type: "string",
+			},
+			tagFormat: {
+				type: "string",
+			},
+			dryRun: {
+				type: "boolean",
+			},
+		},
 	}
 );
 

--- a/bin/runner.js
+++ b/bin/runner.js
@@ -1,14 +1,11 @@
 import { createRequire } from "module";
 
-export default async (flags) => {
+export default async (cliFlags) => {
 	const require = createRequire(import.meta.url);
-
-	if (flags.debug) {
-		require("debug").enable("msr:*");
-	}
 
 	// Imports.
 	const getPackagePaths = (await import("../lib/getPackagePaths.js")).default;
+	const getConfigMultiSemrel = (await import("../lib/getConfigMultiSemrel.js")).default;
 	const multiSemanticRelease = (await import("../lib/multiSemanticRelease.js")).default;
 	const multisemrelPkgJson = require("../package.json");
 	const semrelPkgJson = require("semantic-release/package.json");
@@ -18,6 +15,12 @@ export default async (flags) => {
 
 	// Catch errors.
 	try {
+		const flags = await getConfigMultiSemrel(cwd, cliFlags);
+
+		if (flags.debug) {
+			require("debug").enable("msr:*");
+		}
+
 		console.log(`multi-semantic-release version: ${multisemrelPkgJson.version}`);
 		console.log(`semantic-release version: ${semrelPkgJson.version}`);
 		console.log(`flags: ${JSON.stringify(flags, null, 2)}`);
@@ -34,7 +37,7 @@ export default async (flags) => {
 			},
 			(error) => {
 				// Log out errors.
-				console.error(`[multi-semantic-release111]:`, error);
+				console.error(`[multi-semantic-release]:`, error);
 				process.exit(1);
 			}
 		);

--- a/lib/getConfigMultiSemrel.js
+++ b/lib/getConfigMultiSemrel.js
@@ -1,6 +1,6 @@
+import resolveFrom from "resolve-from";
 import { cosmiconfig } from "cosmiconfig";
-import { default as resolveFrom } from "resolve-from";
-import { pickBy, isNil, castArray } from "lodash-es";
+import { pickBy, isNil, castArray, uniq } from "lodash-es";
 import { createRequire } from "module";
 
 const CONFIG_NAME = "multi-release";
@@ -26,6 +26,8 @@ const mergeConfig = (a = {}, b = {}) => {
 			...a.deps,
 			...pickBy(b.deps, (option) => !isNil(option)),
 		},
+		// Treat arrays differently by merging them
+		ignorePackages: uniq([...castArray(a.ignorePackages || []), ...castArray(b.ignorePackages || [])]),
 	};
 };
 
@@ -63,7 +65,7 @@ export default async function getConfig(cwd, cliOptions) {
 			firstParent: false,
 			debug: false,
 			ignorePrivate: true,
-			ignorePackages: "",
+			ignorePackages: [],
 			tagFormat: "${name}@${version}",
 			dryRun: false,
 			deps: {

--- a/lib/getConfigMultiSemrel.js
+++ b/lib/getConfigMultiSemrel.js
@@ -1,0 +1,67 @@
+import { cosmiconfig } from "cosmiconfig";
+import { default as resolveFrom } from "resolve-from";
+import { pickBy, isNil, castArray } from "lodash-es";
+
+const CONFIG_NAME = "multi-release";
+const CONFIG_FILES = [
+	"package.json",
+	`.${CONFIG_NAME}rc`,
+	`.${CONFIG_NAME}rc.json`,
+	`.${CONFIG_NAME}rc.yaml`,
+	`.${CONFIG_NAME}rc.yml`,
+	`.${CONFIG_NAME}rc.js`,
+	`.${CONFIG_NAME}rc.cjs`,
+	`${CONFIG_NAME}.config.js`,
+	`${CONFIG_NAME}.config.cjs`,
+];
+
+/**
+ * Get the multi semantic release configuration options for a given directory.
+ *
+ * @param {string} cwd The directory to search.
+ * @param {Object} cliOptions cli supplied options.
+ * @returns {Object} The found configuration option
+ *
+ * @internal
+ */
+export default async function getConfig(cwd, cliOptions) {
+	const { config } = (await cosmiconfig(CONFIG_NAME, { searchPlaces: CONFIG_FILES }).search(cwd)) || {};
+	const { extends: extendPaths, ...rest } = { ...config, ...cliOptions };
+
+	let options = rest;
+
+	if (extendPaths) {
+		// If `extends` is defined, load and merge each shareable config with `options`
+		options = {
+			...castArray(extendPaths).reduce((result, extendPath) => {
+				const extendsOptions = require(resolveFrom.silent(__dirname, extendPath) ||
+					resolveFrom(cwd, extendPath));
+				return { ...result, ...extendsOptions };
+			}, {}),
+			...options,
+		};
+	}
+
+	// Set default options values if not defined yet
+	options = {
+		sequentialInit: false,
+		sequentialPrepare: true,
+		firstParent: false,
+		debug: false,
+		ignorePrivate: true,
+		ignorePackages: "",
+		tagFormat: "${name}@${version}",
+		dryRun: false,
+		// Remove `null` and `undefined` options so they can be replaced with default ones
+		...pickBy(options, (option) => !isNil(option)),
+		// Treat nested objects differently as otherwise we'll loose undefined keys
+		deps: {
+			bump: "override",
+			release: "patch",
+			prefix: "",
+			...pickBy(options.deps, (option) => !isNil(option)),
+		},
+	};
+
+	return options;
+}

--- a/lib/getConfigMultiSemrel.js
+++ b/lib/getConfigMultiSemrel.js
@@ -1,6 +1,7 @@
 import { cosmiconfig } from "cosmiconfig";
 import { default as resolveFrom } from "resolve-from";
 import { pickBy, isNil, castArray } from "lodash-es";
+import { createRequire } from "module";
 
 const CONFIG_NAME = "multi-release";
 const CONFIG_FILES = [
@@ -15,6 +16,19 @@ const CONFIG_FILES = [
 	`${CONFIG_NAME}.config.cjs`,
 ];
 
+const mergeConfig = (a = {}, b = {}) => {
+	return {
+		...a,
+		// Remove `null` and `undefined` options so they can be replaced with default ones
+		...pickBy(b, (option) => !isNil(option)),
+		// Treat nested objects differently as otherwise we'll loose undefined keys
+		deps: {
+			...a.deps,
+			...pickBy(b.deps, (option) => !isNil(option)),
+		},
+	};
+};
+
 /**
  * Get the multi semantic release configuration options for a given directory.
  *
@@ -26,42 +40,41 @@ const CONFIG_FILES = [
  */
 export default async function getConfig(cwd, cliOptions) {
 	const { config } = (await cosmiconfig(CONFIG_NAME, { searchPlaces: CONFIG_FILES }).search(cwd)) || {};
-	const { extends: extendPaths, ...rest } = { ...config, ...cliOptions };
+	const { extends: extendPaths, ...rest } = { ...config };
 
 	let options = rest;
 
 	if (extendPaths) {
-		// If `extends` is defined, load and merge each shareable config with `options`
-		options = {
-			...castArray(extendPaths).reduce((result, extendPath) => {
-				const extendsOptions = require(resolveFrom.silent(__dirname, extendPath) ||
-					resolveFrom(cwd, extendPath));
-				return { ...result, ...extendsOptions };
-			}, {}),
-			...options,
-		};
+		const require = createRequire(import.meta.url);
+		// If `extends` is defined, load and merge each shareable config
+		const extendedOptions = castArray(extendPaths).reduce((result, extendPath) => {
+			const extendsOptions = require(resolveFrom(cwd, extendPath));
+			return mergeConfig(result, extendsOptions);
+		}, {});
+
+		options = mergeConfig(options, extendedOptions);
 	}
 
 	// Set default options values if not defined yet
-	options = {
-		sequentialInit: false,
-		sequentialPrepare: true,
-		firstParent: false,
-		debug: false,
-		ignorePrivate: true,
-		ignorePackages: "",
-		tagFormat: "${name}@${version}",
-		dryRun: false,
-		// Remove `null` and `undefined` options so they can be replaced with default ones
-		...pickBy(options, (option) => !isNil(option)),
-		// Treat nested objects differently as otherwise we'll loose undefined keys
-		deps: {
-			bump: "override",
-			release: "patch",
-			prefix: "",
-			...pickBy(options.deps, (option) => !isNil(option)),
+	options = mergeConfig(
+		{
+			sequentialInit: false,
+			sequentialPrepare: true,
+			firstParent: false,
+			debug: false,
+			ignorePrivate: true,
+			ignorePackages: "",
+			tagFormat: "${name}@${version}",
+			dryRun: false,
+			deps: {
+				bump: "override",
+				release: "patch",
+				prefix: "",
+			},
 		},
-	};
+		options
+	);
 
-	return options;
+	// Finally merge CLI options last so they always win
+	return mergeConfig(options, cliOptions);
 }

--- a/package.json
+++ b/package.json
@@ -68,14 +68,15 @@
 		"lodash-es": "^4.17.21",
 		"meow": "^10.1.2",
 		"promise-events": "^0.2.4",
+		"resolve-from": "^5.0.0",
 		"semantic-release": "^19.0.2",
 		"semver": "^7.3.7",
 		"signale": "^1.4.0",
 		"stream-buffers": "^3.0.2"
 	},
 	"devDependencies": {
-		"@jest/globals": "^28.1.0",
 		"@commitlint/config-conventional": "^17.0.0",
+		"@jest/globals": "^28.1.0",
 		"@semantic-release/changelog": "^6.0.1",
 		"@semantic-release/git": "^10.0.1",
 		"@semantic-release/github": "^8.0.4",

--- a/test/fixtures/yarnWorkspacesConfig/package.json
+++ b/test/fixtures/yarnWorkspacesConfig/package.json
@@ -1,0 +1,27 @@
+{
+	"name": "msr-test-yarn",
+	"author": "Dave Houlbrooke <dave@shax.com",
+	"version": "0.0.0-semantically-released",
+	"private": true,
+	"license": "0BSD",
+	"engines": {
+		"node": ">=8.3"
+	},
+	"workspaces": {
+		"packages": ["packages/*"]
+	},
+	"release": {
+		"plugins": [
+			"@semantic-release/commit-analyzer",
+			"@semantic-release/release-notes-generator"
+		],
+		"noCi": true
+	},
+	"multi-release": {
+		"debug": true,
+		"ignorePackages": ["!packages/d/**"],
+		"deps": {
+			"bump": "inherit"
+		}
+	}
+}

--- a/test/fixtures/yarnWorkspacesConfig/packages/a/package.json
+++ b/test/fixtures/yarnWorkspacesConfig/packages/a/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "msr-test-a",
+	"version": "0.0.0",
+	"peerDependencies": {
+		"msr-test-c": "*",
+		"left-pad": "latest"
+	}
+}

--- a/test/fixtures/yarnWorkspacesConfig/packages/b/package.json
+++ b/test/fixtures/yarnWorkspacesConfig/packages/b/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "msr-test-b",
+	"version": "0.0.0",
+	"dependencies": {
+		"msr-test-a": "*"
+	},
+	"devDependencies": {
+		"msr-test-c": "*",
+		"left-pad": "latest"
+	}
+}

--- a/test/fixtures/yarnWorkspacesConfig/packages/c/.releaserc.json
+++ b/test/fixtures/yarnWorkspacesConfig/packages/c/.releaserc.json
@@ -1,0 +1,3 @@
+{
+	"tagFormat": "multi-semantic-release-test-c@v${version}"
+}

--- a/test/fixtures/yarnWorkspacesConfig/packages/c/package.json
+++ b/test/fixtures/yarnWorkspacesConfig/packages/c/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "msr-test-c",
+	"version": "0.0.0",
+	"devDependencies": {
+		"msr-test-b": "*",
+		"msr-test-d": "*"
+	}
+}

--- a/test/fixtures/yarnWorkspacesConfig/packages/d/package.json
+++ b/test/fixtures/yarnWorkspacesConfig/packages/d/package.json
@@ -1,0 +1,4 @@
+{
+	"name": "msr-test-d",
+	"version": "0.0.0"
+}

--- a/test/fixtures/yarnWorkspacesConfigExtends/config.js
+++ b/test/fixtures/yarnWorkspacesConfigExtends/config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	deps: {
+		bump: "satisfy",
+	},
+};

--- a/test/fixtures/yarnWorkspacesConfigExtends/package.json
+++ b/test/fixtures/yarnWorkspacesConfigExtends/package.json
@@ -1,0 +1,28 @@
+{
+	"name": "msr-test-yarn",
+	"author": "Dave Houlbrooke <dave@shax.com",
+	"version": "0.0.0-semantically-released",
+	"private": true,
+	"license": "0BSD",
+	"engines": {
+		"node": ">=8.3"
+	},
+	"workspaces": {
+		"packages": ["packages/*"]
+	},
+	"release": {
+		"plugins": [
+			"@semantic-release/commit-analyzer",
+			"@semantic-release/release-notes-generator"
+		],
+		"noCi": true
+	},
+	"multi-release": {
+		"debug": true,
+		"ignorePackages": ["!packages/d/**"],
+		"deps": {
+			"bump": "inherit"
+		},
+		"extends": ["./config.js"]
+	}
+}

--- a/test/fixtures/yarnWorkspacesConfigExtends/packages/a/package.json
+++ b/test/fixtures/yarnWorkspacesConfigExtends/packages/a/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "msr-test-a",
+	"version": "0.0.0",
+	"peerDependencies": {
+		"msr-test-c": "*",
+		"left-pad": "latest"
+	}
+}

--- a/test/fixtures/yarnWorkspacesConfigExtends/packages/b/package.json
+++ b/test/fixtures/yarnWorkspacesConfigExtends/packages/b/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "msr-test-b",
+	"version": "0.0.0",
+	"dependencies": {
+		"msr-test-a": "*"
+	},
+	"devDependencies": {
+		"msr-test-c": "*",
+		"left-pad": "latest"
+	}
+}

--- a/test/fixtures/yarnWorkspacesConfigExtends/packages/c/.releaserc.json
+++ b/test/fixtures/yarnWorkspacesConfigExtends/packages/c/.releaserc.json
@@ -1,0 +1,3 @@
+{
+	"tagFormat": "multi-semantic-release-test-c@v${version}"
+}

--- a/test/fixtures/yarnWorkspacesConfigExtends/packages/c/package.json
+++ b/test/fixtures/yarnWorkspacesConfigExtends/packages/c/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "msr-test-c",
+	"version": "0.0.0",
+	"devDependencies": {
+		"msr-test-b": "*",
+		"msr-test-d": "*"
+	}
+}

--- a/test/fixtures/yarnWorkspacesConfigExtends/packages/d/package.json
+++ b/test/fixtures/yarnWorkspacesConfigExtends/packages/d/package.json
@@ -1,0 +1,4 @@
+{
+	"name": "msr-test-d",
+	"version": "0.0.0"
+}

--- a/test/lib/getConfigMultiSemrel.test.js
+++ b/test/lib/getConfigMultiSemrel.test.js
@@ -1,0 +1,149 @@
+import getConfig from "../../lib/getConfigMultiSemrel.js";
+import { gitInit } from "../helpers/git.js";
+import { copyDirectory } from "../helpers/file.js";
+
+// Tests.
+describe("getConfig()", () => {
+	test("Default options", async () => {
+		const result = await getConfig(process.cwd(), {});
+		expect(result).toMatchObject({
+			sequentialInit: false,
+			sequentialPrepare: true,
+			firstParent: false,
+			debug: false,
+			ignorePrivate: true,
+			ignorePackages: [],
+			tagFormat: "${name}@${version}",
+			dryRun: false,
+			deps: {
+				bump: "override",
+				release: "patch",
+				prefix: "",
+			},
+		});
+	});
+
+	test("Only CLI flags and default options", async () => {
+		const cliFlags = {
+			debug: true,
+			ignorePackages: ["!packages/d/**"],
+			deps: {
+				bump: "inherit",
+			},
+		};
+		const result = await getConfig(process.cwd(), cliFlags);
+		expect(result).toMatchObject({
+			sequentialInit: false,
+			sequentialPrepare: true,
+			firstParent: false,
+			debug: true,
+			ignorePrivate: true,
+			ignorePackages: ["!packages/d/**"],
+			tagFormat: "${name}@${version}",
+			dryRun: false,
+			deps: {
+				bump: "inherit",
+				release: "patch",
+				prefix: "",
+			},
+		});
+	});
+
+	test("package.json config", async () => {
+		const cwd = await gitInit();
+		copyDirectory(`test/fixtures/yarnWorkspacesConfig/`, cwd);
+		const result = await getConfig(cwd, {});
+		expect(result).toMatchObject({
+			sequentialInit: false,
+			sequentialPrepare: true,
+			firstParent: false,
+			debug: true,
+			ignorePrivate: true,
+			ignorePackages: ["!packages/d/**"],
+			tagFormat: "${name}@${version}",
+			dryRun: false,
+			deps: {
+				bump: "inherit",
+				release: "patch",
+				prefix: "",
+			},
+		});
+	});
+
+	test("package.json config and CLI flags", async () => {
+		const cwd = await gitInit();
+		const cliFlags = {
+			debug: false,
+			ignorePackages: ["!packages/c/**"],
+			deps: {
+				release: "minor",
+			},
+		};
+		copyDirectory(`test/fixtures/yarnWorkspacesConfig/`, cwd);
+		const result = await getConfig(cwd, cliFlags);
+		expect(result).toMatchObject({
+			sequentialInit: false,
+			sequentialPrepare: true,
+			firstParent: false,
+			debug: false,
+			ignorePrivate: true,
+			ignorePackages: ["!packages/d/**", "!packages/c/**"],
+			tagFormat: "${name}@${version}",
+			dryRun: false,
+			deps: {
+				bump: "inherit",
+				release: "minor",
+				prefix: "",
+			},
+		});
+	});
+
+	test("package.json extends", async () => {
+		const cwd = await gitInit();
+		copyDirectory(`test/fixtures/yarnWorkspacesConfigExtends/`, cwd);
+		const result = await getConfig(cwd, {});
+		expect(result).toMatchObject({
+			sequentialInit: false,
+			sequentialPrepare: true,
+			firstParent: false,
+			debug: true,
+			ignorePrivate: true,
+			ignorePackages: ["!packages/d/**"],
+			tagFormat: "${name}@${version}",
+			dryRun: false,
+			deps: {
+				bump: "satisfy",
+				release: "patch",
+				prefix: "",
+			},
+		});
+	});
+
+	test("package.json extends and CLI flags", async () => {
+		const cwd = await gitInit();
+		const cliFlags = {
+			debug: false,
+			ignorePackages: ["!packages/c/**"],
+			deps: {
+				release: "minor",
+			},
+		};
+		copyDirectory(`test/fixtures/yarnWorkspacesConfigExtends/`, cwd);
+		const result = await getConfig(cwd, cliFlags);
+		expect(result).toMatchObject({
+			sequentialInit: false,
+			sequentialPrepare: true,
+			firstParent: false,
+			debug: false,
+			ignorePrivate: true,
+			ignorePackages: ["!packages/d/**", "!packages/c/**"],
+			tagFormat: "${name}@${version}",
+			dryRun: false,
+			deps: {
+				bump: "satisfy",
+				release: "minor",
+				prefix: "",
+			},
+		});
+	});
+});


### PR DESCRIPTION
## feat: added declarative config support

Adds declarative config support to multi-semantic-release.

Config can be declared in any `multi-release.*` file or under `multi-release` in package.json. The config will be merged with cli flags, with cli flags taking precedence.

Fixes #72 

## Changes

- Created a new `lib/getConfigMultiSemrel.js` file, this function accepts cli flags, and merges them with flags read from disk, as well as setting default options. It also supports resolving shareable config's from node_modules or relative paths.

- Removed setting the default flag values in `cli.js`, this is now done in `lib/getConfigMultiSemrel.js` 

- Changed `runner.js` to read config from `lib/getConfigMultiSemrel.js` before attempting to enable debug mode, or logging flags.

## Todo

- [x] New code is covered by tests
- [x] All the changes are mentioned in docs (readme.md)
