### PR TITLE
fix: ensure msr cli flags take precedence over their semrel equivalents

### DIFF
--- a/lib/getConfigMultiSemrel.js
+++ b/lib/getConfigMultiSemrel.js
@@ -67,7 +67,7 @@ export default async function getConfig(cwd, cliOptions) {
 			ignorePrivate: true,
 			ignorePackages: [],
 			tagFormat: "${name}@${version}",
-			dryRun: false,
+			dryRun: undefined,
 			deps: {
 				bump: "override",
 				release: "patch",

--- a/lib/multiSemanticRelease.js
+++ b/lib/multiSemanticRelease.js
@@ -180,8 +180,7 @@ async function releasePackage(pkg, createInlinePlugin, multiContext, flags) {
 	// This consists of:
 	// - The global options (e.g. from the top level package.json)
 	// - The package options (e.g. from the specific package's package.json)
-	// TODO filter flags
-	const options = { ...flags, ...pkgOptions, ...inlinePlugin };
+	const options = { ...pkgOptions, ...inlinePlugin };
 
 	// Add the package name into tagFormat.
 	// Thought about doing a single release for the tag (merging several packages), but it's impossible to prevent Github releasing while allowing NPM to continue.
@@ -193,6 +192,14 @@ async function releasePackage(pkg, createInlinePlugin, multiContext, flags) {
 
 	const tagFormatDefault = "${name}@${version}";
 	options.tagFormat = template(flags.tagFormat || tagFormatDefault)(tagFormatCtx);
+
+	// These are the only two options that MSR shares with semrel
+	// Set them manually for now, defaulting to the msr versions
+	// This is approach can be reviewed if there's ever more crossover.
+	// - debug is only supported in semrel as a CLI arg, always default to MSR
+	options.debug = flags.debug;
+	// - dryRun should use the msr version if specified, otherwise fallback to semrel
+	options.dryRun = flags.dryRun === undefined ? options.dryRun : flags.dryRun;
 
 	// This options are needed for plugins that do not rely on `pluginOptions` and extract them independently.
 	options._pkgOptions = pkgOptions;

--- a/test/lib/getConfigMultiSemrel.test.js
+++ b/test/lib/getConfigMultiSemrel.test.js
@@ -14,7 +14,7 @@ describe("getConfig()", () => {
 			ignorePrivate: true,
 			ignorePackages: [],
 			tagFormat: "${name}@${version}",
-			dryRun: false,
+			dryRun: undefined,
 			deps: {
 				bump: "override",
 				release: "patch",
@@ -26,6 +26,7 @@ describe("getConfig()", () => {
 	test("Only CLI flags and default options", async () => {
 		const cliFlags = {
 			debug: true,
+			dryRun: false,
 			ignorePackages: ["!packages/d/**"],
 			deps: {
 				bump: "inherit",
@@ -61,7 +62,7 @@ describe("getConfig()", () => {
 			ignorePrivate: true,
 			ignorePackages: ["!packages/d/**"],
 			tagFormat: "${name}@${version}",
-			dryRun: false,
+			dryRun: undefined,
 			deps: {
 				bump: "inherit",
 				release: "patch",
@@ -89,7 +90,7 @@ describe("getConfig()", () => {
 			ignorePrivate: true,
 			ignorePackages: ["!packages/d/**", "!packages/c/**"],
 			tagFormat: "${name}@${version}",
-			dryRun: false,
+			dryRun: undefined,
 			deps: {
 				bump: "inherit",
 				release: "minor",
@@ -110,7 +111,7 @@ describe("getConfig()", () => {
 			ignorePrivate: true,
 			ignorePackages: ["!packages/d/**"],
 			tagFormat: "${name}@${version}",
-			dryRun: false,
+			dryRun: undefined,
 			deps: {
 				bump: "satisfy",
 				release: "patch",
@@ -138,7 +139,7 @@ describe("getConfig()", () => {
 			ignorePrivate: true,
 			ignorePackages: ["!packages/d/**", "!packages/c/**"],
 			tagFormat: "${name}@${version}",
-			dryRun: false,
+			dryRun: undefined,
 			deps: {
 				bump: "satisfy",
 				release: "minor",


### PR DESCRIPTION
<!-- 
Add a link to issue, another PR, discussion with which this PR is associated.
Select the most suitable relation type: fixes / closes / relates
-->
Fixes #78 - CLI flags not taking any effect when also defined in `.releaserc.js` file

<!-- Maybe you'd like to discuss this at first? Your may always create a new issue / discussion topic -->

## Changes
<!-- What exactly you have changed, and how it works now -->

Given that msr only shares two options with semrel, `debug` and `dryRun`, set them manually rather than merging the full flags object.

- `--debug`: Can only be passed to semrel as a CLI flag, given we are invoking semrel programmatically, we always default to the msr version.
- `--dryRun`: Use the msr version if specified regardless of if it is `true` or `false`, otherwise fallback to the semrel value.

## Chores

- [x] New code is covered by tests
- [x] All the changes are mentioned in docs (readme.md)