### PR TITLE
fix(runner): don't display flags and path in silent mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Alternatively some options may be set via CLI flags.
 | ------ | ---- | -------- | ----------- |
 | dryRun | `boolean` | `--dry-run` | Dry run mode. |
 | debug | `boolean` | `--debug` | Output debugging information. |
+| silent | `boolean` | `--silent` | Do not print configuration information. |
 | extends | `String \| Array` | N/A | List of modules or file paths containing a shareable configuration. If multiple shareable configurations are set, they will be imported in the order defined with each configuration option taking precedence over the options defined in the previous. |
 | sequentialInit | `boolean` | `--sequential-init` | Avoid hypothetical concurrent initialization collisions. |
 | sequentialPrepare | `boolean` | `--sequential-prepare` | Avoid hypothetical concurrent preparation collisions. **True by default.** |

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -13,6 +13,7 @@ const cli = meow(
   Options
     --dry-run Dry run mode.
     --debug Output debugging information.
+    --silent Do not print configuration information.
     --sequential-init  Avoid hypothetical concurrent initialization collisions.
     --sequential-prepare  Avoid hypothetical concurrent preparation collisions. Do not use if your project have cyclic dependencies.
     --first-parent Apply commit filtering to current branch only.
@@ -68,6 +69,9 @@ const cli = meow(
 				type: "string",
 			},
 			dryRun: {
+				type: "boolean",
+			},
+			silent: {
 				type: "boolean",
 			},
 		},

--- a/bin/runner.js
+++ b/bin/runner.js
@@ -1,4 +1,5 @@
 import { createRequire } from "module";
+import dbg from "debug";
 
 export default async (cliFlags) => {
 	const require = createRequire(import.meta.url);
@@ -21,13 +22,15 @@ export default async (cliFlags) => {
 			require("debug").enable("msr:*");
 		}
 
+		const debug = dbg("msr:runner");
+
 		console.log(`multi-semantic-release version: ${multisemrelPkgJson.version}`);
 		console.log(`semantic-release version: ${semrelPkgJson.version}`);
-		console.log(`flags: ${JSON.stringify(flags, null, 2)}`);
+		debug(`flags: ${JSON.stringify(flags, null, 2)}`);
 
 		// Get list of package.json paths according to workspaces.
 		const paths = getPackagePaths(cwd, flags.ignorePackages);
-		console.log("package paths", paths);
+		debug("package paths", paths);
 
 		// Do multirelease (log out any errors).
 		multiSemanticRelease(paths, {}, { cwd }, flags).then(

--- a/bin/runner.js
+++ b/bin/runner.js
@@ -17,11 +17,13 @@ export default async (cliFlags) => {
 	try {
 		const flags = await getConfigMultiSemrel(cwd, cliFlags);
 
+		const silent = flags.silent && !flags.debug;
+
 		if (flags.debug) {
 			require("debug").enable("msr:*");
 		}
 
-		if (!flags.silent) {
+		if (!silent) {
 			console.log(`multi-semantic-release version: ${multisemrelPkgJson.version}`);
 			console.log(`semantic-release version: ${semrelPkgJson.version}`);
 			console.log(`flags: ${JSON.stringify(flags, null, 2)}`);
@@ -29,7 +31,7 @@ export default async (cliFlags) => {
 
 		// Get list of package.json paths according to workspaces.
 		const paths = getPackagePaths(cwd, flags.ignorePackages);
-		if (!flags.silent) {
+		if (!silent) {
 			console.log("package paths", paths);
 		}
 

--- a/bin/runner.js
+++ b/bin/runner.js
@@ -1,5 +1,4 @@
 import { createRequire } from "module";
-import dbg from "debug";
 
 export default async (cliFlags) => {
 	const require = createRequire(import.meta.url);
@@ -22,15 +21,17 @@ export default async (cliFlags) => {
 			require("debug").enable("msr:*");
 		}
 
-		const debug = dbg("msr:runner");
-
-		console.log(`multi-semantic-release version: ${multisemrelPkgJson.version}`);
-		console.log(`semantic-release version: ${semrelPkgJson.version}`);
-		debug(`flags: ${JSON.stringify(flags, null, 2)}`);
+		if (!flags.silent) {
+			console.log(`multi-semantic-release version: ${multisemrelPkgJson.version}`);
+			console.log(`semantic-release version: ${semrelPkgJson.version}`);
+			console.log(`flags: ${JSON.stringify(flags, null, 2)}`);
+		}
 
 		// Get list of package.json paths according to workspaces.
 		const paths = getPackagePaths(cwd, flags.ignorePackages);
-		debug("package paths", paths);
+		if (!flags.silent) {
+			console.log("package paths", paths);
+		}
 
 		// Do multirelease (log out any errors).
 		multiSemanticRelease(paths, {}, { cwd }, flags).then(

--- a/lib/getConfigMultiSemrel.js
+++ b/lib/getConfigMultiSemrel.js
@@ -73,6 +73,7 @@ export default async function getConfig(cwd, cliOptions) {
 				release: "patch",
 				prefix: "",
 			},
+			silent: false,
 		},
 		options
 	);

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 		"meow": "^10.1.2",
 		"promise-events": "^0.2.4",
 		"resolve-from": "^5.0.0",
-		"semantic-release": "^19.0.2",
+		"semantic-release": "^19.0.5",
 		"semver": "^7.3.7",
 		"signale": "^1.4.0",
 		"stream-buffers": "^3.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5594,10 +5594,10 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-semantic-release@^19.0.3:
-  version "19.0.3"
-  resolved "https://registry.yarnpkg.com/semantic-release/-/semantic-release-19.0.3.tgz#9291053ad9890052f28e7c5921d4741530d516fd"
-  integrity sha512-HaFbydST1cDKZHuFZxB8DTrBLJVK/AnDExpK0s3EqLIAAUAHUgnd+VSJCUtTYQKkAkauL8G9CucODrVCc7BuAA==
+semantic-release@^19.0.2:
+  version "19.0.5"
+  resolved "https://registry.yarnpkg.com/semantic-release/-/semantic-release-19.0.5.tgz#d7fab4b33fc20f1288eafd6c441e5d0938e5e174"
+  integrity sha512-NMPKdfpXTnPn49FDogMBi36SiBfXkSOJqCkk0E4iWOY1tusvvgBwqUmxTX1kmlT6kIYed9YwNKD1sfPpqa5yaA==
   dependencies:
     "@semantic-release/commit-analyzer" "^9.0.2"
     "@semantic-release/error" "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5594,7 +5594,7 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-semantic-release@^19.0.2:
+semantic-release@^19.0.5:
   version "19.0.5"
   resolved "https://registry.yarnpkg.com/semantic-release/-/semantic-release-19.0.5.tgz#d7fab4b33fc20f1288eafd6c441e5d0938e5e174"
   integrity sha512-NMPKdfpXTnPn49FDogMBi36SiBfXkSOJqCkk0E4iWOY1tusvvgBwqUmxTX1kmlT6kIYed9YwNKD1sfPpqa5yaA==


### PR DESCRIPTION
## Changes
Displaying flags every time might clutter the output.
Now the flags are only displayed if debug mode is enabled (using config or CLI flag).

The same is done for the paths (those are displayed afterward by multi-semantic-release anyway).
