### PR TITLE
feat(debug): add a verbose mode to debug semantic-release

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -13,6 +13,7 @@ const cli = meow(
   Options
     --dry-run Dry run mode.
     --debug Output debugging information.
+    --verbose Also debug semantic release
     --silent Do not print configuration information.
     --sequential-init  Avoid hypothetical concurrent initialization collisions.
     --sequential-prepare  Avoid hypothetical concurrent preparation collisions. Do not use if your project have cyclic dependencies.
@@ -72,6 +73,9 @@ const cli = meow(
 				type: "boolean",
 			},
 			silent: {
+				type: "boolean",
+			},
+			verbose: {
 				type: "boolean",
 			},
 		},

--- a/bin/runner.js
+++ b/bin/runner.js
@@ -21,6 +21,10 @@ export default async (cliFlags) => {
 
 		if (flags.debug) {
 			require("debug").enable("msr:*");
+
+			if (flags.verbose) {
+				require("debug").enable("semantic-release:*");
+			}
 		}
 
 		if (!silent) {

--- a/lib/getConfigMultiSemrel.js
+++ b/lib/getConfigMultiSemrel.js
@@ -74,6 +74,7 @@ export default async function getConfig(cwd, cliOptions) {
 				prefix: "",
 			},
 			silent: false,
+			verbose: false,
 		},
 		options
 	);


### PR DESCRIPTION
Fixes #79

## Changes

When trying to debug my release config, I needed to access `semantic-release` debug mode.
I come up with this solution

- [x] All the changes are mentioned in docs (readme.md)
