### PR TITLE
fix: don't touch packages with 'workspace' set as a package version

### DIFF
--- a/lib/updateDeps.js
+++ b/lib/updateDeps.js
@@ -240,7 +240,8 @@ const resolveNextVersion = (currentVersion, nextVersion, strategy = "override", 
 	// Check the next pkg version against its current references.
 	// If it matches (`*` matches to any, `1.1.0` matches `1.1.x`, `1.5.0` matches to `^1.0.0` and so on)
 	// release will not be triggered, if not `override` strategy will be applied instead.
-	if ((strategy === "satisfy" || strategy === "inherit") && semver.satisfies(nextVersion, currentVersion)) {
+	// If currentVersion has "workspace" inside it means it shouldn't be checked with semver.satisfies as it's covered by yarn's/pnpm's/npm's workspaces versioning
+	if (currentVersion.includes("workspace") || (strategy === "satisfy" || strategy === "inherit") && semver.satisfies(nextVersion, currentVersion)) {
 		return currentVersion;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/qiwi/multi-semantic-release/issues/87

## Changes
It skips connected packages that has 'workspace' e.g. 'workspace:*' keyword set as version number.

- [ ] New code is covered by tests
- [ ] All the changes are mentioned in docs (readme.md)
