### PR TITLE
fix: --deps.bump not working as expected

### DIFF
--- a/lib/updateDeps.js
+++ b/lib/updateDeps.js
@@ -205,7 +205,7 @@ const getDependentRelease = (pkg, bumpStrategy, releaseStrategy, ignore, prefix)
 			return false;
 		}
 
-		const resolvedVersion = resolveNextVersion(currentVersion, nextVersion, releaseStrategy, prefix);
+		const resolvedVersion = resolveNextVersion(currentVersion, nextVersion, bumpStrategy, prefix);
 		if (currentVersion !== resolvedVersion) {
 			scope[name] = resolvedVersion;
 			return true;


### PR DESCRIPTION
Fixes #83

## Changes
Use `bumpStrategy` instead of `releaseStrategy` when calling `resolveNextVersion`

- [ ] New code is covered by tests
- [ ] All the changes are mentioned in docs (readme.md)
